### PR TITLE
SITES-126: Check drush output for warnings

### DIFF
--- a/roles/sync-site/tasks/main.yml
+++ b/roles/sync-site/tasks/main.yml
@@ -63,6 +63,7 @@
     - "vset install_profile stanford_dept"
     - "cc all"
     - "sqlq 'update system set status=\"1\" where name=\"stanford_dept\"'"
+    - "rr"
   when: dept_site == "TRUE"
 
 - name: Do post-database-restore tasks
@@ -121,12 +122,12 @@
 
 - name: Print file_public_path
   debug:
-    msg: "File public path: {{ file_public_path }}"
+    msg: "File public path: {{ file_public_path.stdout }}"
 
 - name: Be sure response does not include drush warnings
   fail:
     msg: "There appear to be drush warning messages cluttering the file_public_path variable"
-  when: file_public_path | search('Inordertofixthis')
+  when: file_public_path.stdout | search('The following module is missing')
 
 - name: Replace sites/default/files with path to files directory
   shell: "drush @{{ drush_alias_environment }}.{{ stack }}.{{ acsf_site_name }} sar -y 'sites/default/files' '{{ file_public_path.stdout | replace(' ','') }}'"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- We rely on drush output for setting the new files path and Ansible considers drush warnings part of stdout, not stderr.  This means, warnings and errors can get into the files path variable value and cause problems.  For example:

![screen shot 2017-10-12 at 4 55 06 pm](https://user-images.githubusercontent.com/4072139/31524398-379bba48-af6e-11e7-891f-bb10417bd561.png)

Should really look like:

![screen shot 2017-10-12 at 4 56 07 pm](https://user-images.githubusercontent.com/4072139/31524410-45d5f56a-af6e-11e7-92eb-7f65438c5e68.png)

# Needed By
- Before you pull 0.0.2 or 0.0.3 updates to production, because there is a helpful issue with 0.0.1, which allows us to see this error.

# Urgency
- We certainly don't want this issue creeping in silently to our pilot sites.

# Steps to Test

1. Before updating the ACSF prod instance and before it gets re-provisioned, checkout this branch.
2. Update your migration_vars.yml to be able to run the playbook against our production environment.
3. `supri-b` is a great site to test this with, since we know that it was failing today (see first screenshot above).  So I would include only this site in your inventory.
4. Run: ansible-playbook -i inventory/sites migration-playbook.yml
5.  And you should not see this error.  The site should migrate successfully.
6. To see this error, remove `- "rr"` from roles/sync-site/tasks/main.yml.
7. Rerun: ansible-playbook -i inventory/sites migration-playbook.yml
8. The play should fail at: `Be sure response does not include drush warnings`.

# Associated Issues and/or People
- I've been referencing: https://stanfordits.atlassian.net/browse/SITES-126.