### PR TITLE
SITES-178: Set up Backtrac for 9 Earth pilot sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Exclude files from repository
 *.DS_Store
 *.retry
+backtrac_vars.yml
 migration_vars.yml
 server_vars.yml

--- a/backtrac-playbook.yml
+++ b/backtrac-playbook.yml
@@ -1,0 +1,24 @@
+---
+# Ansible playbook that recreates in Site Factory sites on our infrastructure.
+# https://github.com/SU-SWS/ansible-playbooks
+# ============================================================================
+#
+# This playbook sets up Backtrac projects for sites that we are migrating to
+# Acquia Cloud Site Factory.
+#
+# Can be run with:
+# ansible-playbook -i inventory/backtrac backtrac-playbook.yml
+#
+# KNOWN ISSUES:
+# --
+#
+# PLAY 1: Set up backtrac projects
+# ================================
+- hosts: all
+  connection: local
+
+  vars_files:
+    - backtrac_vars.yml
+
+  roles:
+    - backtrac-create

--- a/backtrac-playbook.yml
+++ b/backtrac-playbook.yml
@@ -1,5 +1,6 @@
 ---
-# Ansible playbook that recreates in Site Factory sites on our infrastructure.
+# Ansible playbook that creates projects on Backtrac for sites that we are
+# migrating to ACSF.
 # https://github.com/SU-SWS/ansible-playbooks
 # ============================================================================
 #

--- a/default.backtrac
+++ b/default.backtrac
@@ -1,0 +1,6 @@
+# Default inventory file for Backtrac.
+# Copy this and put it in the "inventory" directory.
+
+#dekaslab prod_url="https://dekaslab.stanford.edu/" stage_url="http://dekaslab.stanford.acsitefactory.com/" paths="people,research,publications,opportunities"
+dekaslab prod_url="https://dekaslab.stanford.edu/" stage_url="http://dekaslab.stanford.acsitefactory.com/"
+

--- a/default.backtrac_vars.yml
+++ b/default.backtrac_vars.yml
@@ -1,0 +1,11 @@
+# Personal or local values for Backtrac.
+# https://github.com/SU-SWS/ansible-playbooks
+# ================================================
+#
+# Save a copy of this file to the ansible-playbooks root directory
+# and name it backtrac_vars.yml.
+#
+#
+# Enter your API Key Backtrac, https://backtrac.io/user#tabs-3.
+backtrac_api_key: ""
+

--- a/roles/backtrac-create/meta/main.yml
+++ b/roles/backtrac-create/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/roles/backtrac-create/tasks/main.yml
+++ b/roles/backtrac-create/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+# Ansible role for creating Backtrac projects from an inventory.
+# https://github.com/SU-SWS/ansible-playbooks
+# ================================================================
+#
+# The purpose of this role is to create Backtrac projects via the API.
+#
+# INPUTS:
+#   backtrac_api_key
+#   inventory_hostname
+#   prod_url
+#   stage_url
+#   paths
+#
+# OUTPUTS:
+# --
+#
+# ALTERNATIVE ROLES:
+# --
+#
+# REQUIREMENTS:
+# --
+#
+# KNOWN ISSUES:
+# --
+#
+#- name: Check if project exists on Backtrac
+
+- name: Create backtrac projects from an inventory
+  uri:
+    url: "https://backtrac.io/api/project"
+    method: POST
+    headers:
+      x-api-key: "{{ backtrac_api_key }}"
+    body_format: json
+    body:
+      title: "{{ inventory_hostname }}"
+      prod:
+        url: "{{ prod_url }}"
+      stage:
+        url: "{{ stage_url }}"
+#      uris: "{{ paths }}"
+    force_basic_auth: yes
+    return_content: yes
+  register: existing_sites
+
+- name: Print out return json
+  debug:
+    msg: "{{ existing_sites }}"


### PR DESCRIPTION
# NOT READY

# Summary
- It is failing with an "Access Denied" error. When I submit requests against the API _not_ using Ansible (e.g., with curl or Postman), I can generate the same "Access Denied" error by using the wrong value for the `x-api-key` header. This leads me to believe that the header is not being set correctly by Ansible.

