### PR TITLE
SITES-160: sanitize site names

### DIFF
--- a/migration-playbook.yml
+++ b/migration-playbook.yml
@@ -37,6 +37,7 @@
     - { role: download-site, tags: [download-site] }
     - { role: setup-site, tags: [setup-site,download-site] }
     - { role: upload-site, tags: [upload-site,setup-site,download-site] }
+    - { role: get-sitename, tags: [upload-site,setup-site,download-site] }
     - { role: add-vhost, tags: [add-vhost,upload-site,setup-site,download-site] }
     - { role: cleanup-local, tags: [cleanup-local,upload-site,setup-site,download-site] }
   serial: 12

--- a/roles/add-vhost/tasks/main.yml
+++ b/roles/add-vhost/tasks/main.yml
@@ -11,6 +11,7 @@
 #   sitefactory_environment
 #   acquia_username
 #   acquia_api_key
+#   existing_sites
 #
 # OUTPUTS:
 # --
@@ -26,15 +27,11 @@
 
 - name: Establish numerical id from existing_sites JSON response
   set_fact:
-    site_id: "{{ existing_sites | json_query(\"json.sites[?site=='\" + acsf_site_name + \"'].id\") }}"
+    site_id: "{{ existing_sites | json_query(existing_sites_query) }}"
+  vars:
+    existing_sites_query: "json.sites[?site=='{{ acsf_site_name }}'] | [0].id"
 
-- name: Establish numerical id from API JSON response if site did not exist
-  set_fact:
-    site_id: "{{ site_created | json_query(\"json.id\") }}"
-  when:
-    site_id > 0
-
-#- name: Debug site_id variable
+#- name: Debug json formatting on sites_created id
 #  debug:
 #    var: site_id
 

--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -14,6 +14,7 @@
 #   stack_id
 #   acquia_username
 #   acquia_api_key
+#   existing_sites
 #
 # OUTPUTS:
 #   site_created
@@ -45,3 +46,10 @@
 
 - pause:
     minutes: 1
+
+- name: Check drush can bootstrap site
+  shell: "drush @{{ drush_alias_environment }}.{{ stack }}.{{ acsf_site_name }} status --fields='Drupal bootstrap' --field-labels=0 --strict=0"
+  retries: "{{ wait_time }}"
+  delay: 50
+  register: bootstrap_status
+  until: bootstrap_status.stdout | search('Successful')

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -32,13 +32,6 @@
 # KNOWN ISSUES:
 # --
 
-- name: Check drush can bootstrap site
-  shell: "drush @{{ drush_alias_environment }}.{{ stack }}.{{ acsf_site_name }} status --fields='Drupal bootstrap' --field-labels=0 --strict=0"
-  retries: "{{ wait_time }}"
-  delay: 50
-  register: bootstrap_status
-  until: bootstrap_status.stdout | search('Successful')
-
 - name: Drop database in Site Factory and install new database
   shell: "drush @{{ drush_alias_environment }}.{{ stack }}.{{ acsf_site_name }} {{ item }}"
   with_items:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This should be the last of this ticket. This commit adds a custom domain if we've sanitized the site name from `inventory_hostname`.
- The check for `when: site_id > 0` could be more robust (https://github.com/SU-SWS/ansible-playbooks/pull/12/files#diff-ac85741a35df97c0e3a57b4a52ac0af3R35). I couldn't find a way to evaluate if a variable was an integer. It was getting set as `[]` in https://github.com/SU-SWS/ansible-playbooks/pull/12/files#diff-ac85741a35df97c0e3a57b4a52ac0af3R29, so I just checked if it was greater than 0.

# Needed By (Date)
- Friday, October 27th

# Criticality
- How critical is this PR on a 1-10 scale? 7
- It's a pretty big usability win.

# Steps to Test

On any environment (prod, test, dev):

1. Delete the `pursuingsustainability` site if it exists
2. Add `pursuing-sustainability` to `inventory/sites`
3. Run `ansible-playbook -i inventory/sites migration-playbook.yml`
4. Once finished, confirm that the site can be reached at http://pursuing-sustainability.cardinalsites.stanford.edu (as well as http://pursuingsustainability.cardinalsites.stanford.edu)

Improvements to logic and Ansible best practices are welcome.

# Affected Projects or Products
- Earth pilot

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-160
- Any other contextual information that might be helpful: we likely will hit some issues with this sanitization approach. We could legitimately have `sws-test` and `swstest` and they would collide. We'll burn that bridge when we get to it, I suppose.