### PR TITLE
SITES-236: Remove webauth role history before uninstall

### DIFF
--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -55,6 +55,7 @@
     - "-y updb"
     - "-y en acsf nobots stanford_ssp"
     - "-y dis googleanalytics pingdom_rum"
+    - "sqlq 'truncate table webauth_roles_history'"
     - "sspwmd"
   notify: Clear site cache
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- During the uninstall process, WebAuth removes any roles that it had assigned users.  This meant, during the migration process, users were losing any roles previously assigned to them by WebAuth.  Even though SAML should, technically, re-grant them any roles associated with their affiliations and workgroup entitlements, we wanted the migration to ensure any roles someone might have accumulated on the Sites environment stayed with them, regardless of their current workgroups.

# Needed By (11/21)

# Urgency
- On a scale from 1 to 10, perhaps a 7?

# Steps to Test

1. Check out this branch.
2. Migrate paleobiology and ensure that:
* Clare has admin, SSO User, Stanford Staff, and SUNet User.
This can be done with `drush @acsf.[env].cardinald7.paleobiology sqlq 'select * from users_roles where uid=3'`.  This should be what you see:
```
3	5
3	7
3	11
3	14
```

# Affected Projects or Products
- Sites 2.0 pilot

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SITES-236