### PR TITLE
SITES-224: Further Earth migration cleanup

### DIFF
--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -131,7 +131,7 @@
   with_items:
     - "sar -y 'href=\"/{{ inventory_hostname }}/' 'href=\"/'"
     - "sar -y 'src=\"/{{ inventory_hostname }}/' 'src=\"/'"
-    - "sar -y 'url=\"/{{ inventory_hostname }}/' 'src=\"/'"
+    - "sar -y 'url=\"/{{ inventory_hostname }}/' 'url=\"/'"
   notify: Clear site cache
 
 ##############################################################################


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
1. Sets the custom domain to be sitename(-dev|-test).cardinalsites.stanford.edu
2. Sets drush aliases to use https://sitename(-dev|-test).cardinalsites.stanford.edu as the URL syntax
3. Sets ACSF to allow local user logins
4. Improves find/replace handling of `drush sar` so that it doesn't clobber external links

# Needed By (Date)
- 11.28.2017 if possible

# Criticality
- How critical is this PR on a 1-10 scale? 8
- The Earth pilot depends on it

# Steps to Test

1. Run `ansible-playbook server-settings-playbook.yml` with an inventory that only has the **dev** servers
2. Create an inventory (`inventory/sites`) for cloning:
````
paleobiology vhost="paleobiology"
sccs vhost="sccs"
SITES224 vhost="sites224"
supri-b vhost="supri-b"
````
3. Run `ansible-playbook -i inventory/sites migration-playbook.yml`
4. Verify that `drush @acsf.dev.cardinald7.suprib uli` logs you into https://supri-b-dev.cardinalsites.stanford.edu/ (you are verifying `https` and the custom domain)
5. Go to https://paleobiology-dev.cardinalsites.stanford.edu/people and ensure that the link to "Paleobiology Group" under Jonathan Payne's bio goes to https://pangea.stanford.edu/researchgroups/paleobiology/ (it previously was stripping the trailing `/paleobiology`)
6. Go to https://sccs-dev.cardinalsites.stanford.edu/about/affiliate-opportunities and ensure that the link to "Stanford University Policies Affecting Industrial Affiliates Program Memberships" downloads a PDF from doresearch.stanford.edu
7. Go to https://sites224-dev.cardinalsites.stanford.edu and verify that all of the internal and external links are working correctly.

# Affected Projects or Products
- Sites 2.0
- Earth pilot

# Associated Issues and/or People
- JIRA tickets:
    - https://stanfordits.atlassian.net/browse/SITES-224
    - https://stanfordits.atlassian.net/browse/SITES-248
- Anyone who should be notified? ( @sherakama FYI )
