### PR TITLE
SITES-439: Use vhost when available for sar/l/m

### DIFF
--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -96,8 +96,8 @@
     # Text fields should replace http(s)://sites.stanford.edu/sitename with
     # https://acsf_site_name.cardinalsites.stanford.edu, or
     # https://vhost.cardinalsites.stanford.edu when one exists.
-    - "sar -y 'http://sites.stanford.edu/{{ inventory_hostname }}/' 'https://{% if vhost %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
-    - "sar -y 'https://sites.stanford.edu/{{ inventory_hostname }}/' 'https://{% if vhost %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
+    - "sar -y 'http://sites.stanford.edu/{{ inventory_hostname }}/' 'https://{% if vhost is defined %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
+    - "sar -y 'https://sites.stanford.edu/{{ inventory_hostname }}/' 'https://{% if vhost is defined %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
     # Menus and links should replace http(s)://sites.stanford.edu/sitename with nothing.
     - "sarm -y 'http://sites.stanford.edu/{{ inventory_hostname }}/' ''"
     - "sarm -y 'https://sites.stanford.edu/{{ inventory_hostname }}/' ''"

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -79,8 +79,8 @@
     # when/if we decide on a URL syntax for people sites. Also, we are using
     # {{ acsf_site_name }} here because we can rely on it being the same as
     # the person's SUNetID due to validation rules for SUNetIDs.
-    - "sar -y 'http://people.stanford.edu/{{ inventory_hostname }}/' 'https://{% if vhost %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
-    - "sar -y 'https://people.stanford.edu/{{ inventory_hostname }}/' 'https://{% if vhost %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
+    - "sar -y 'http://people.stanford.edu/{{ inventory_hostname }}/' 'https://{{ acsf_site_name }}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
+    - "sar -y 'https://people.stanford.edu/{{ inventory_hostname }}/' 'https://{{ acsf_site_name }}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
     # Menus and links should replace http(s)://people.stanford.edu/sunetid with nothing.
     - "sarm -y 'http://people.stanford.edu/{{ inventory_hostname }}/' ''"
     - "sarm -y 'https://people.stanford.edu/{{ inventory_hostname }}/' ''"
@@ -94,11 +94,8 @@
   shell: "drush @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }} {{ item }}"
   with_items:
     # Text fields should replace http(s)://sites.stanford.edu/sitename with
-    # https://acsf_site_name.cardinalsites.stanford.edu. Do nothing for vhosts;
-    # references will point to the on-prem site before cutover, and to the ACSF
-    # site after cutover (note that this is an assumption). Also, we are using
-    # {{ acsf_site_name }} here because we can rely on it existing, regardless
-    # whether there's a vhost.
+    # https://acsf_site_name.cardinalsites.stanford.edu, or
+    # https://vhost.cardinalsites.stanford.edu when one exists.
     - "sar -y 'http://sites.stanford.edu/{{ inventory_hostname }}/' 'https://{% if vhost %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
     - "sar -y 'https://sites.stanford.edu/{{ inventory_hostname }}/' 'https://{% if vhost %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
     # Menus and links should replace http(s)://sites.stanford.edu/sitename with nothing.

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -79,8 +79,8 @@
     # when/if we decide on a URL syntax for people sites. Also, we are using
     # {{ acsf_site_name }} here because we can rely on it being the same as
     # the person's SUNetID due to validation rules for SUNetIDs.
-    - "sar -y 'http://people.stanford.edu/{{ inventory_hostname }}/' 'https://{{ acsf_site_name }}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
-    - "sar -y 'https://people.stanford.edu/{{ inventory_hostname }}/' 'https://{{ acsf_site_name }}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
+    - "sar -y 'http://people.stanford.edu/{{ inventory_hostname }}/' 'https://{% if vhost %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
+    - "sar -y 'https://people.stanford.edu/{{ inventory_hostname }}/' 'https://{% if vhost %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
     # Menus and links should replace http(s)://people.stanford.edu/sunetid with nothing.
     - "sarm -y 'http://people.stanford.edu/{{ inventory_hostname }}/' ''"
     - "sarm -y 'https://people.stanford.edu/{{ inventory_hostname }}/' ''"
@@ -99,8 +99,8 @@
     # site after cutover (note that this is an assumption). Also, we are using
     # {{ acsf_site_name }} here because we can rely on it existing, regardless
     # whether there's a vhost.
-    - "sar -y 'http://sites.stanford.edu/{{ inventory_hostname }}/' 'https://{{ acsf_site_name }}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
-    - "sar -y 'https://sites.stanford.edu/{{ inventory_hostname }}/' 'https://{{ acsf_site_name }}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
+    - "sar -y 'http://sites.stanford.edu/{{ inventory_hostname }}/' 'https://{% if vhost %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
+    - "sar -y 'https://sites.stanford.edu/{{ inventory_hostname }}/' 'https://{% if vhost %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}{{ stanford_environment }}.cardinalsites.stanford.edu/'"
     # Menus and links should replace http(s)://sites.stanford.edu/sitename with nothing.
     - "sarm -y 'http://sites.stanford.edu/{{ inventory_hostname }}/' ''"
     - "sarm -y 'https://sites.stanford.edu/{{ inventory_hostname }}/' ''"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- In testing, Clare noticed that the "member companies" link on the supri-b homepage was https://suprib.cardinalsites.stanford.edu, which her browser was treating as a different session for the purposes of authentication.  So we are changing link rewrites to use the vhost when one is available.

# Needed By (Mon.)

# Urgency
- Pretty urgent, as we plan to launch Earth's sites on Tues.  While supri-b will not be part of the launch list, it would be good to have consistency around this transformation.

# Steps to Test

1. Check out this branch.
2. You can try migrating supri-b to dev, I previously migrated it to test.  Try migrating as well a site without a vhost.
3. Check that the `member companies` path on their homepage links to https://supri-b-dev.cardinalsites.stanford.edu/affiliates/affiliate-program.  And successfully takes you to this page.
4. Check that the scripts don't fail for host without a vhost.  And that their links show the acsf_site_name value.

# Affected Projects or Products
- Earth pilot

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SITES-439