### PR TITLE
SITES-472: Allow for migrating multiple orgs at once

### DIFF
--- a/group_vars/depts.yml
+++ b/group_vars/depts.yml
@@ -5,11 +5,6 @@
 # These values will be used when Ansible runs the migration playbook
 # against hosts listed under the [depts] inventory group.
 #
-# Enter the Site Factory Group ID or ID's within which this site should
-# appear in the Site Factory dashboard.
-# Example: "126,127" or "126"
-group_ids: 336
-#
 # Enter the server from which we should pull the live site's database and
 # and files. Unless the sites are people sites, we'll probably want to
 # pull copies from `sites2`.

--- a/group_vars/groups.yml
+++ b/group_vars/groups.yml
@@ -5,11 +5,6 @@
 # These values will be used when Ansible runs the migration playbook
 # against hosts listed under the [groups] inventory group.
 #
-# Enter the Site Factory Group ID or ID's within which this site should
-# appear in the Site Factory dashboard.
-# Example: "126,127" or "126"
-group_ids: 336
-#
 # Enter the server from which we should pull the live site's database and
 # and files. Unless the sites are people sites, we'll probably want to
 # pull copies from `sites2`.

--- a/inventory/default.sites
+++ b/inventory/default.sites
@@ -1,0 +1,17 @@
+# Default inventory file. Copy this and put it in the "inventory" directory.
+
+[education]
+# Add sitenames here
+
+[earth]
+# Add sitenames here
+
+[depts:children]
+education
+earth
+
+[education:vars]
+group_ids=621
+
+[earth:vars]
+group_ids=336


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Previously, we had set group_ids by whether the site was a group, department, or personal site.  This means that if we migrated sites from both Earth and Education during the same playbook run, they would both end up in the same group.  However, our groups are organized by Organization, so the Earth sites need to go into the Earth group and the Education sites need to go into the Education group.

# Needed By (5/3)
- End of sprint

# Urgency
- 4

# Steps to Test

1. Checkout this branch.
2. Rename your existing sites inventory to something else, like `sites-old`.
3. Copy the new `default.sites` inventory to `sites` and add at least one site per group: education and earth.  Previously, I used `eao` and `g2scd7`.
4. Run the migration scripts on `test` with: `ansible-playbook -i inventory/sites migration-playbook.yml`
5. Check https://www.test-cardinalsites.acsitefactory.com to be sure your sites were migrated into the correct group.

# Affected Projects or Products
- Sites 2.0

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SITES-472

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)