### PR TITLE
SITES-465: Not launch and launch path handling

### DIFF
--- a/roles/add-vhost/tasks/main.yml
+++ b/roles/add-vhost/tasks/main.yml
@@ -26,7 +26,7 @@
 # KNOWN ISSUES:
 # --
 
-- name: Add vhost as domain
+- name: Add custom domain
   uri:
     url: "https://www.{{ sitefactory_environment }}cardinalsites.acsitefactory.com/api/v1/domains/{{ site_id }}/add"
     method: POST
@@ -35,22 +35,4 @@
     force_basic_auth: yes
     body_format: json
     body:
-      domain_name: "{{ vhost }}{{ stanford_environment }}.cardinalsites.stanford.edu"
-  when:
-    vhost is defined
-
-# Ex. drupal7-update-status.cardinalsites.stanford.edu.
-- name: Add inventory_hostname as domain
-  uri:
-    url: "https://www.{{ sitefactory_environment }}cardinalsites.acsitefactory.com/api/v1/domains/{{ site_id }}/add"
-    method: POST
-    user: "{{ acquia_username }}"
-    password: "{{ acquia_api_key }}"
-    force_basic_auth: yes
-    body_format: json
-    body:
-      domain_name: "{{ inventory_hostname }}{{ stanford_environment }}.cardinalsites.stanford.edu"
-    return_content: yes
-    register: inventory_hostname_domain_response
-  when:
-    inventory_hostname != acsf_site_name
+      domain_name: "{{ new_absolute_path }}"

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -12,6 +12,7 @@
 #   site_prefix
 #   stack
 #   vhost
+#   launch_tasks
 #
 # OUTPUTS:
 #   sites_service
@@ -53,15 +54,20 @@
   set_fact:
     absolute_path_testing: "{% if vhost is defined %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}-{{ acsf_environment }}.cardinalsites.stanford.edu"
 
-# Ex: g2sc.stanford.edu
-- name: Set absolute path for production
+# Ex: g2sc.cardinalsites.stanford.edu
+- name: Set absolute path for production pre-launch
   set_fact:
-    absolute_path_prod: "{% if vhost is defined %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}.stanford.edu"
+    absolute_path_prod: "{% if vhost is defined %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}.cardinalsites.stanford.edu"
+
+# Ex: g2sc.stanford.edu
+- name: Set absolute path for production at launch
+  set_fact:
+    absolute_path_launch: "{% if vhost is defined %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}.stanford.edu"
 
 # Ex: g2sc-dev.cardinalsites.stanford.edu if migrating to dev
 - name: Set new absolute path based on destination
   set_fact:
-    new_absolute_path: "{% if acsf_environment == '' %}{{ absolute_path_prod }}{% else %}{{ absolute_path_testing }}{% endif %}"
+    new_absolute_path: "{% if launch_tasks == 'launch' %}{{ absolute_path_launch }}{% elseif acsf_environment == '' %}{{ absolute_path_production }}{% else %}{{ absolute_path_testing }}{% endif %}"
 
 - name: Debug absolute path for site
   debug:

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -51,14 +51,21 @@
   shell: "{{drush_alias }} {{ item }}"
   with_items:
     - "-y updb"
-    - "-y en acsf nobots stanford_ssp paranoia"
+    - "-y en acsf stanford_ssp paranoia"
     - "ev 'acsf_openid_allow_local_user_logins();'"
     - 'ev "_paranoia_remove_risky_permissions();"'
-    - "-y dis googleanalytics pingdom_rum"
     - "-y dis stanford_afs_quota"
     # Must truncate this table otherwise users will lose roles in WMD->SSP upgrade path.
     - "sqlq 'truncate table webauth_roles_history'"
     - "sspwmd"
+  notify: Clear site cache
+
+- name: Post-database-restore tasks if not launch
+  shell: "{{ drush_alias }} {{ item }}"
+  with_items:
+    - "-y en nobots"
+    - "y dis googleanalytics pingdom_rum"
+  when: launch_tasks == ""
   notify: Clear site cache
 
 # Copy public files first so that they exist and Drupal can find them if needed


### PR DESCRIPTION
# NOT READY

# Summary
- When we migrate sites to production for testing, we will need to access them at foo.cardinalsites.stanford.edu.  At launch, we'll need to access them at foo.stanford.edu if they have a vhost.  To make sure any absolute paths written during the migration process reflect these two different states, I've added a new launch_tasks variable to specify whether a migration is for launch, and should therefore use the domain foo.stanford.edu.

# Needed By (5/17)
- Today is the end of a sprint, but there is no external deadline requiring the work be merged today.

# Urgency
- 3

# Steps to Test

1. Checkout this branch.  It is based off your css-injector work.
2. We'll want to test this with three different runs.  1) on dev with the launch_tasks variable set to empty.  2) on prod with the launch_tasks variable set to empty.  3) on prod with the launch_tasks variable set to `launch`.
3. With each run, check the output for `define-paths` to be sure the new_absolute_path variable reflects both the environment and whether it is a launch or not.  Reminder: launch on prod would be foo.stanford.edu.  Non-launch on prod would be foo.cardinalsites.stanford.edu.

# Affected Projects or Products
- Sites 2.0 migration script

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SITES-465
- Previous launch branch: https://github.com/SU-SWS/ansible-playbooks/pull/25
- Built on: https://github.com/SU-SWS/ansible-playbooks/pull/32