### PR TITLE
SITES-465: Handle launch and pre-launch paths separately

### DIFF
--- a/default.migration_vars.yml
+++ b/default.migration_vars.yml
@@ -12,6 +12,10 @@
 # prod: enter ""
 acsf_environment: "dev"
 #
+# Set this variable to `launch` if this is the final migration to
+# production before a site goes live.
+launch_tasks: ""
+#
 # Enter the number of minutes you should wait for all sites to complete
 # spinup on Site Factory. In general, it appears ACSF spins up 3 sites at a
 # time and that each batch takes around 6 minutes. So if you are migrating

--- a/roles/add-vhost/tasks/main.yml
+++ b/roles/add-vhost/tasks/main.yml
@@ -36,6 +36,7 @@
     body:
       domain_name: "{{ new_absolute_path }}"
 
+# Ex. drupal7-update-status.cardinalsites.stanford.edu.
 - name: Add inventory_hostname as domain
   uri:
     url: "https://www.{{ sitefactory_environment }}cardinalsites.acsitefactory.com/api/v1/domains/{{ site_id }}/add"

--- a/roles/add-vhost/tasks/main.yml
+++ b/roles/add-vhost/tasks/main.yml
@@ -7,12 +7,11 @@
 # existence of a vhost for a site in Site Factory.
 #
 # INPUTS:
-#   acsf_site_name
 #   sitefactory_environment
-#   stanford_environment
 #   acquia_username
 #   acquia_api_key
-#   existing_sites
+#   site_id
+#   new_absolute_path
 #
 # OUTPUTS:
 # --
@@ -26,7 +25,7 @@
 # KNOWN ISSUES:
 # --
 
-- name: Add vhost as domain
+- name: Add custom domain
   uri:
     url: "https://www.{{ sitefactory_environment }}cardinalsites.acsitefactory.com/api/v1/domains/{{ site_id }}/add"
     method: POST
@@ -35,22 +34,4 @@
     force_basic_auth: yes
     body_format: json
     body:
-      domain_name: "{{ vhost }}{{ stanford_environment }}.cardinalsites.stanford.edu"
-  when:
-    vhost is defined
-
-# Ex. drupal7-update-status.cardinalsites.stanford.edu.
-- name: Add inventory_hostname as domain
-  uri:
-    url: "https://www.{{ sitefactory_environment }}cardinalsites.acsitefactory.com/api/v1/domains/{{ site_id }}/add"
-    method: POST
-    user: "{{ acquia_username }}"
-    password: "{{ acquia_api_key }}"
-    force_basic_auth: yes
-    body_format: json
-    body:
-      domain_name: "{{ inventory_hostname }}{{ stanford_environment }}.cardinalsites.stanford.edu"
-    return_content: yes
-    register: inventory_hostname_domain_response
-  when:
-    inventory_hostname != acsf_site_name
+      domain_name: "{{ new_absolute_path }}"

--- a/roles/add-vhost/tasks/main.yml
+++ b/roles/add-vhost/tasks/main.yml
@@ -35,3 +35,18 @@
     body_format: json
     body:
       domain_name: "{{ new_absolute_path }}"
+
+- name: Add inventory_hostname as domain
+  uri:
+    url: "https://www.{{ sitefactory_environment }}cardinalsites.acsitefactory.com/api/v1/domains/{{ site_id }}/add"
+    method: POST
+    user: "{{ acquia_username }}"
+    password: "{{ acquia_api_key }}"
+    force_basic_auth: yes
+    body_format: json
+    body:
+      domain_name: "{{ inventory_hostname }}{{ stanford_environment }}.cardinalsites.stanford.edu"
+    return_content: yes
+    register: inventory_hostname_domain_response
+  when:
+    inventory_hostname != acsf_site_name

--- a/roles/add-vhost/tasks/main.yml
+++ b/roles/add-vhost/tasks/main.yml
@@ -7,11 +7,11 @@
 # existence of a vhost for a site in Site Factory.
 #
 # INPUTS:
-#   sitefactory_environment
-#   acquia_username
 #   acquia_api_key
-#   site_id
+#   acquia_username
 #   new_absolute_path
+#   site_id
+#   sitefactory_environment
 #
 # OUTPUTS:
 # --

--- a/roles/change-paths/tasks/main.yml
+++ b/roles/change-paths/tasks/main.yml
@@ -148,7 +148,7 @@
 # in "Update full paths in text" or "Update full vhost paths in text". But it's
 # cheap to loop through.
 # TODO: Determine how to treat for final migration (SITES-465)
-# Ex. drush sar -y 'src="https://g2sc.stanford.edu/sites/default/files' 'src="https://g2sc.cardinalsites.stanford.edu/sites/g/sbiybj5000986/f'
+# Ex. drush sar -y 'src="https://g2sc.stanford.edu/sites/default/files' 'src="https://g2sc.cardinalsites.stanford.edu/sites/g/files/sbiybj5000986/f'
 - name: Replace absolute sites/default/files with path to files directory
   shell: "{{ drush_alias }} {{ item[0] }} -y '{{ item[1] }}{{ item[2] }}{{ new_absolute_path }}/sites/default/files' '{{ item[1] }}{{ item[2] }}{{ new_absolute_path }}/{{ file_public_path.stdout | replace(' ','') }}'"
   with_nested:
@@ -159,7 +159,7 @@
 # Same here: we already replaced absolute references in href and src
 # attributes, so we only need to replace the "sites/default/files" string
 # with the ACSF file_public_path value.
-# Ex. drush sar -y 'src="/sites/default/files' 'src="/sites/g/sbiybj5000986/f'
+# Ex. drush sar -y 'src="/sites/default/files' 'src="/sites/g/files/sbiybj5000986/f'
 - name: Replace relative sites/default/files paths with path to files directory
   shell: "{{ drush_alias }} {{ item[0] }} -y '{{ item[1] }}/sites/default/files' '{{ item[1] }}/{{ file_public_path.stdout | replace(' ','') }}'"
   with_nested:

--- a/roles/change-paths/tasks/main.yml
+++ b/roles/change-paths/tasks/main.yml
@@ -48,7 +48,6 @@
 
 # See discussion in https://github.com/SU-SWS/ansible-playbooks/pull/17
 # And https://github.com/SU-SWS/ansible-playbooks/pull/22
-# TODO: Determine how to treat for final migration (SITES-465)
 # Ex: drush sar -y 'https://sites.stanford.edu/g2scd7/' 'https://g2sc-dev.cardinalsites.stanford.edu/'
 - name: Update full paths in text
   shell: "{{ drush_alias }} {{ item[0] }} -y '{{ item[1] }}{{ absolute_path_sites_service }}/' 'https://{{ new_absolute_path }}/'"
@@ -147,7 +146,6 @@
 # {{ protocols }} here (http and https), as we should have already handled that
 # in "Update full paths in text" or "Update full vhost paths in text". But it's
 # cheap to loop through.
-# TODO: Determine how to treat for final migration (SITES-465)
 # Ex. drush sar -y 'src="https://g2sc.stanford.edu/sites/default/files' 'src="https://g2sc.cardinalsites.stanford.edu/sites/g/files/sbiybj5000986/f'
 - name: Replace absolute sites/default/files with path to files directory
   shell: "{{ drush_alias }} {{ item[0] }} -y '{{ item[1] }}{{ item[2] }}{{ new_absolute_path }}/sites/default/files' '{{ item[1] }}{{ item[2] }}{{ new_absolute_path }}/{{ file_public_path.stdout | replace(' ','') }}'"

--- a/roles/change-paths/tasks/main.yml
+++ b/roles/change-paths/tasks/main.yml
@@ -8,15 +8,19 @@
 # of this role fails for a site, restart from the tag "download-site".
 #
 # INPUTS:
+#   absolute_path_sites_service
+#   absolute_vhost_path_sites_service
 #   acsf_site_name
+#   drush_alias
 #   inventory_hostname
-#   sitefactory_environment
-#   drush_environment
-#   site_prefix
-#   stack
+#   link_attributes
+#   new_absolute_path
+#   protocols
+#   sar_fulltext_commands
+#   sarl_commands
 #
 # OUTPUTS:
-#   file_public_path
+# --
 #
 # ALTERNATIVE ROLES:
 # --

--- a/roles/check-php/tasks/main.yml
+++ b/roles/check-php/tasks/main.yml
@@ -9,6 +9,7 @@
 #
 # INPUTS:
 #   inventory_hostname
+#   parens
 #   php_syntax
 #   php_callbacks
 #   php_candidates_consequence_prompted

--- a/roles/css-injector/defaults/main.yml
+++ b/roles/css-injector/defaults/main.yml
@@ -1,8 +1,20 @@
 ---
-all_sar_commands: [ 'sar', 'sarl', 'sarm', 'sarv', 'sarjs' ]
-sarl_commands: [ 'sarl', 'sarm' ]
-sar_fulltext_commands: [ 'sar', 'sarv', 'sarjs' ]
-protocols: [ 'https://', 'http://' ]
+all_sar_commands:
+  - sar
+  - sarl
+  - sarm
+  - sarv
+  - sarjs
+sarl_commands:
+  - sarl
+  - sarm
+sar_fulltext_commands:
+  - sar
+  - sarv
+  - sarjs
+protocols:
+  - https://
+  - http://
 url_regex:
   - url(..)
 url_replace:

--- a/roles/css-injector/tasks/main.yml
+++ b/roles/css-injector/tasks/main.yml
@@ -8,15 +8,17 @@
 # of this role fails for a site, restart from the tag "download-site".
 #
 # INPUTS:
+#   absolute_path_sites_service
+#   absolute_vhost_path_sites_service
 #   acsf_site_name
 #   inventory_hostname
-#   sitefactory_environment
-#   drush_environment
-#   site_prefix
-#   stack
+#   new_absolute_path
+#   protocols
+#   url_regex
+#   url_replace
 #
 # OUTPUTS:
-#   file_public_path
+#   css_injector_files
 #
 # ALTERNATIVE ROLES:
 # --

--- a/roles/css-injector/tasks/main.yml
+++ b/roles/css-injector/tasks/main.yml
@@ -3,9 +3,9 @@
 # https://github.com/SU-SWS/ansible-playbooks
 # ==================================================================
 #
-# This role runs a number of tasks to transform the database in such a way that
-# images and absolute paths will work in the new ACSF environment. If any part
-# of this role fails for a site, restart from the tag "download-site".
+# This role runs a number of tasks to transform CSS Injector files in such a way
+# that images and absolute paths will work in the new ACSF environment. If any
+# part of this role fails for a site, restart from the tag "download-site".
 #
 # INPUTS:
 #   absolute_path_sites_service

--- a/roles/css-injector/tasks/main.yml
+++ b/roles/css-injector/tasks/main.yml
@@ -4,13 +4,11 @@
 # ==================================================================
 #
 # This role runs a number of tasks to transform CSS Injector files in such a way
-# that images and absolute paths will work in the new ACSF environment. If any
-# part of this role fails for a site, restart from the tag "download-site".
+# that images and absolute paths will work in the new ACSF environment.
 #
 # INPUTS:
 #   absolute_path_sites_service
 #   absolute_vhost_path_sites_service
-#   acsf_site_name
 #   inventory_hostname
 #   new_absolute_path
 #   protocols

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -3,14 +3,14 @@
 # https://github.com/SU-SWS/ansible-playbooks
 # ==================================================================
 #
-# This role is required for "change-paths" and "css-injector".
-#
 # INPUTS:
 #   acsf_site_name
-#   inventory_hostname
+#   acsf_environment
 #   drush_environment
-#   site_prefix
 #   stack
+#   inventory_hostname
+#   site_prefix
+#   sites_service
 #   vhost
 #   launch_tasks
 #
@@ -19,9 +19,11 @@
 #   absolute_vhost_path_sites_service
 #   absolute_path_sites_service
 #   absolute_path_testing
+#   absolute_path_launch
 #   absolute_path_prod
 #   new_absolute_path
 #   drush_alias
+#   file_public_path
 #
 # ALTERNATIVE ROLES:
 # --

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -3,6 +3,9 @@
 # https://github.com/SU-SWS/ansible-playbooks
 # ==================================================================
 #
+# This role is required for "change-paths", "css-injector", "setup-site",
+#   and "upload-site".
+#
 # INPUTS:
 #   acsf_site_name
 #   acsf_environment

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -7,27 +7,27 @@
 #   and "upload-site".
 #
 # INPUTS:
-#   acsf_site_name
 #   acsf_environment
+#   acsf_site_name
 #   drush_environment
-#   stack
 #   inventory_hostname
+#   launch_tasks
 #   site_prefix
 #   sites_service
+#   stack
 #   vhost
-#   launch_tasks
 #
 # OUTPUTS:
-#   sites_service
-#   absolute_vhost_path_sites_service
-#   absolute_path_sites_service
-#   absolute_path_testing
 #   absolute_path_launch
 #   absolute_path_prod
-#   new_absolute_path
+#   absolute_path_sites_service
+#   absolute_path_testing
+#   absolute_vhost_path_sites_service
 #   drush_alias
 #   file_public_path
+#   new_absolute_path
 #   scripts_dir
+#   sites_service
 #
 # ALTERNATIVE ROLES:
 # --

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - name: What is the scripts_dir variable
   debug:
-msg: "scripts_dir is: {{ scripts_dir}}"
+    msg: "scripts_dir is: {{ scripts_dir}}"
 
 # Ex: sites
 - name: Set sites_service variable

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -69,7 +69,7 @@
 # Ex: g2sc-dev.cardinalsites.stanford.edu if migrating to dev
 - name: Set new absolute path based on destination
   set_fact:
-    new_absolute_path: "{% if launch_tasks == 'launch' %}{{ absolute_path_launch }}{% elseif acsf_environment == '' %}{{ absolute_path_production }}{% else %}{{ absolute_path_testing }}{% endif %}"
+    new_absolute_path: "{% if launch_tasks == 'launch' %}{{ absolute_path_launch }}{% elif acsf_environment == '' %}{{ absolute_path_production }}{% else %}{{ absolute_path_testing }}{% endif %}"
 
 - name: Debug absolute path for site
   debug:

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -83,7 +83,7 @@
 # Ex: g2sc-dev.cardinalsites.stanford.edu if migrating to dev
 - name: Set new absolute path based on destination
   set_fact:
-    new_absolute_path: "{% if launch_tasks == 'launch' %}{{ absolute_path_launch }}{% elif acsf_environment == '' %}{{ absolute_path_production }}{% else %}{{ absolute_path_testing }}{% endif %}"
+    new_absolute_path: "{% if launch_tasks == 'launch' %}{{ absolute_path_launch }}{% elif acsf_environment == '' %}{{ absolute_path_prod }}{% else %}{{ absolute_path_testing }}{% endif %}"
 
 - name: Debug absolute path for site
   debug:

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -37,6 +37,17 @@
 # KNOWN ISSUES:
 # --
 
+# Ex. /var/www/html/cardinald7.02live/scripts
+# Ex. /var/www/html/cardinald7.02test/scripts
+# Ex. /var/www/html/cardinald7.02dev/scripts
+- name: Set scripts_dir variable
+  set_fact:
+    scripts_dir: "/var/www/html/{{ stack }}.02{% if acsf_environment=='' %}live{% elif acsf_environment=='test'%}test{% elif acsf_environment=='dev'%}dev{% endif %}/scripts"
+
+- name: What is the scripts_dir variable
+  debug:
+msg: "scripts_dir is: {{ scripts_dir}}"
+
 # Ex: sites
 - name: Set sites_service variable
   set_fact:

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -27,6 +27,7 @@
 #   new_absolute_path
 #   drush_alias
 #   file_public_path
+#   scripts_dir
 #
 # ALTERNATIVE ROLES:
 # --
@@ -80,8 +81,8 @@
   set_fact:
     absolute_path_launch: "{% if vhost is defined %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}.stanford.edu"
 
-# Ex: g2sc-dev.cardinalsites.stanford.edu if migrating to dev,
-#     g2sc.stanford.edu if launch_tasks = 'launch'
+# Ex: "g2sc-dev.cardinalsites.stanford.edu" if migrating to dev,
+#     "g2sc.stanford.edu" if launch_tasks = "launch"
 - name: Set new absolute path based on destination
   set_fact:
     new_absolute_path: "{% if launch_tasks == 'launch' %}{{ absolute_path_launch }}{% elif acsf_environment == '' %}{{ absolute_path_prod }}{% else %}{{ absolute_path_testing }}{% endif %}"

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -80,7 +80,8 @@
   set_fact:
     absolute_path_launch: "{% if vhost is defined %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}.stanford.edu"
 
-# Ex: g2sc-dev.cardinalsites.stanford.edu if migrating to dev
+# Ex: g2sc-dev.cardinalsites.stanford.edu if migrating to dev,
+#     g2sc.stanford.edu if launch_tasks = 'launch'
 - name: Set new absolute path based on destination
   set_fact:
     new_absolute_path: "{% if launch_tasks == 'launch' %}{{ absolute_path_launch }}{% elif acsf_environment == '' %}{{ absolute_path_prod }}{% else %}{{ absolute_path_testing }}{% endif %}"

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -12,6 +12,7 @@
 #   site_prefix
 #   stack
 #   vhost
+#   launch_tasks
 #
 # OUTPUTS:
 #   sites_service
@@ -30,17 +31,6 @@
 #
 # KNOWN ISSUES:
 # --
-
-# Ex. /var/www/html/cardinald7.02live/scripts
-# Ex. /var/www/html/cardinald7.02test/scripts
-# Ex. /var/www/html/cardinald7.02dev/scripts
-- name: Set scripts_dir variable
-  set_fact:
-    scripts_dir: "/var/www/html/{{ stack }}.02{% if acsf_environment=='' %}live{% elif acsf_environment=='test'%}test{% elif acsf_environment=='dev'%}dev{% endif %}/scripts"
-
-- name: What is the scripts_dir variable
-  debug:
-    msg: "scripts_dir is: {{ scripts_dir}}"
 
 # Ex: sites
 - name: Set sites_service variable
@@ -64,15 +54,20 @@
   set_fact:
     absolute_path_testing: "{% if vhost is defined %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}-{{ acsf_environment }}.cardinalsites.stanford.edu"
 
-# Ex: g2sc.stanford.edu
-- name: Set absolute path for production
+# Ex: g2sc.cardinalsites.stanford.edu
+- name: Set absolute path for production pre-launch
   set_fact:
-    absolute_path_prod: "{% if vhost is defined %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}.stanford.edu"
+    absolute_path_prod: "{% if vhost is defined %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}.cardinalsites.stanford.edu"
+
+# Ex: g2sc.stanford.edu
+- name: Set absolute path for production at launch
+  set_fact:
+    absolute_path_launch: "{% if vhost is defined %}{{ vhost }}{% else %}{{ acsf_site_name }}{% endif %}.stanford.edu"
 
 # Ex: g2sc-dev.cardinalsites.stanford.edu if migrating to dev
 - name: Set new absolute path based on destination
   set_fact:
-    new_absolute_path: "{% if acsf_environment == '' %}{{ absolute_path_prod }}{% else %}{{ absolute_path_testing }}{% endif %}"
+    new_absolute_path: "{% if launch_tasks == 'launch' %}{{ absolute_path_launch }}{% elseif acsf_environment == '' %}{{ absolute_path_production }}{% else %}{{ absolute_path_testing }}{% endif %}"
 
 - name: Debug absolute path for site
   debug:

--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -7,18 +7,19 @@
 # existence of a site in Site Factory.
 #
 # INPUTS:
-#   inventory_hostname
-#   sitefactory_environment
-#   profile
-#   group_ids
-#   stack_id
-#   acquia_username
 #   acquia_api_key
-#   existing_sites
+#   acquia_username
 #   drush_alias
+#   existing_sites
+#   group_ids
+#   inventory_hostname
+#   profile
+#   sitefactory_environment
+#   stack_id
 #   wait_time
 #
 # OUTPUTS:
+#   bootstrap_status
 #   site_created
 #
 # ALTERNATIVE ROLES:

--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -15,6 +15,8 @@
 #   acquia_username
 #   acquia_api_key
 #   existing_sites
+#   drush_alias
+#   wait_time
 #
 # OUTPUTS:
 #   site_created

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -51,14 +51,21 @@
   shell: "{{drush_alias }} {{ item }}"
   with_items:
     - "-y updb"
-    - "-y en acsf nobots stanford_ssp paranoia"
+    - "-y en acsf stanford_ssp paranoia"
     - "ev 'acsf_openid_allow_local_user_logins();'"
     - 'ev "_paranoia_remove_risky_permissions();"'
-    - "-y dis googleanalytics pingdom_rum"
     - "-y dis stanford_afs_quota"
     # Must truncate this table otherwise users will lose roles in WMD->SSP upgrade path.
     - "sqlq 'truncate table webauth_roles_history'"
     - "sspwmd"
+  notify: Clear site cache
+
+- name: Post-database-restore tasks if not launch
+  shell: "{{ drush_alias }} {{ item }}"
+  with_items:
+    - "-y en nobots"
+    - "y dis googleanalytics pingdom_rum"
+  when: launch_tasks == ""
   notify: Clear site cache
 
 # Copy public files first so that they exist and Drupal can find them if needed

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -64,7 +64,7 @@
   shell: "{{ drush_alias }} {{ item }}"
   with_items:
     - "-y en nobots"
-    - "y dis googleanalytics pingdom_rum"
+    - "-y dis googleanalytics pingdom_rum"
   when: launch_tasks == ""
   notify: Clear site cache
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When we migrate sites to production for testing, we will need to access them at foo.cardinalsites.stanford.edu.  At launch, we'll need to access them at foo.stanford.edu if they have a vhost.  To make sure any absolute paths written during the migration process reflect these two different states, I've added a new launch_tasks variable to specify whether a migration is for launch, and should therefore use the domain foo.stanford.edu.

# Needed By (5/28)
- Slightly before end of sprint, so we can wrap this work into a release.

# Urgency
- 4

# Steps to Test

1. Checkout this branch.
2.  Add the launch_tasks variable to your migration_vars.yml file (new example is in default.migration_vars.yml).
2. We'll want to test this with three different runs.  1) on dev with the launch_tasks variable set to empty.  2) on prod with the launch_tasks variable set to empty.  3) on prod with the launch_tasks variable set to `launch`.
3. With each run, check the output for `define-paths` to be sure the new_absolute_path variable reflects both the environment and whether it is a launch or not.  Reminder: launch on prod would be foo.stanford.edu.  Non-launch on prod would be foo.cardinalsites.stanford.edu.

# Affected Projects or Products
- Sites 2.0 migration script

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SITES-465
- Previous launch branch: https://github.com/SU-SWS/ansible-playbooks/pull/25
- Built on: https://github.com/SU-SWS/ansible-playbooks/pull/32