### PR TITLE
SITES-530: Run drush updb earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ This is a small collection of Ansible roles that we are using to migrate sites f
 
 ## Installation
 
-1. If not already installed, `pip install ansible` or `brew install ansible`
-2. `git clone git@github.com:SU-SWS/ansible-playbooks.git`
-3. `cd ansible-playbooks`
+1. If not already installed, `pip3 install ansible` or `brew install ansible`
+2. Install jmespath: `pip3 install jmespath`
+3. `git clone git@github.com:SU-SWS/ansible-playbooks.git`
+4. `cd ansible-playbooks`
 
 ## Migrating Sites
 ````
@@ -36,17 +37,31 @@ ansible-playbook -i inventory/servers server-settings-playbook.yml
 
 1. Copy `default.servers` to `inventory/servers`.
 2. Copy `default.server_vars.yml` to the root `ansible-playbooks` directory and name it `server_vars.yml`. Populate it with your information.
-3. Run: `ansible-playbook -i inventory/servers server-settings-playbook.yml` 
+3. Run: `ansible-playbook -i inventory/servers server-settings-playbook.yml`
 
 ## Troubleshooting
 
-If a task fails, you can re-run the playbook from where it failed with: 
+### Failed Tasks
+
+If a task fails, you can re-run the playbook from where it failed with:
 
 ```
 ansible-playbook -i inventory/[inventory-filename] migration-playbook.yml --tags "[rolename]"
 ```
 
 You can also add `-v(vvv)` for more debug information.
+
+### SSL Issues
+
+If you are on OSX and are having SSL certificate troubles please view: https://docs.ansible.com/ansible/latest/reference_appendices/python_3_support.html
+
+It may help to add one of the following to `migration_vars.yml`
+```
+ansible_python_interpreter=/usr/local/bin/python3
+ansible_python_interpreter=/usr/bin/python3
+```
+
+Or run `ansible-playbook` with the `-e ansible_python_interpreter=/usr/local/bin/python3` option.
 
 ## Contribution / Collaboration
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -51,7 +51,7 @@ inventory       = inventory
 # with a maximum timeout of 10 seconds. This
 # option lets you increase or decrease that
 # timeout to something more suitable for the
-# environment. 
+# environment.
 # gather_timeout = 10
 
 # additional paths to search for roles in, colon separated
@@ -351,16 +351,16 @@ log_path = /tmp/ansible.log
 # paramiko on older platforms rather than removing it, -C controls compression use
 #ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s
 
-# The base directory for the ControlPath sockets. 
+# The base directory for the ControlPath sockets.
 # This is the "%(directory)s" in the control_path option
-# 
-# Example: 
+#
+# Example:
 # control_path_dir = /tmp/.ansible/cp
 #control_path_dir = ~/.ansible/cp
 
-# The path to use for the ControlPath sockets. This defaults to a hashed string of the hostname, 
-# port and username (empty string in the config). The hash mitigates a common problem users 
-# found with long hostames and the conventional %(directory)s/ansible-ssh-%%h-%%p-%%r format. 
+# The path to use for the ControlPath sockets. This defaults to a hashed string of the hostname,
+# port and username (empty string in the config). The hash mitigates a common problem users
+# found with long hostames and the conventional %(directory)s/ansible-ssh-%%h-%%p-%%r format.
 # In those cases, a "too long for Unix domain socket" ssh error would occur.
 #
 # Example:
@@ -399,8 +399,8 @@ log_path = /tmp/ansible.log
 [persistent_connection]
 
 # Configures the persistent connection timeout value in seconds.  This value is
-# how long the persistent connection will remain idle before it is destroyed.  
-# If the connection doesn't receive a request before the timeout value 
+# how long the persistent connection will remain idle before it is destroyed.
+# If the connection doesn't receive a request before the timeout value
 # expires, the connection is shutdown.  The default value is 30 seconds.
 #connect_timeout = 30
 
@@ -409,7 +409,7 @@ log_path = /tmp/ansible.log
 # to the local domain socket.  The default value is 30.
 #connect_retries = 30
 
-# Configures the amount of time in seconds to wait between connection attempts 
+# Configures the amount of time in seconds to wait between connection attempts
 # to the local unix domain socket.  This value works in conjunction with the
 # connect_retries value to define how long to try to connect to the local
 # domain socket when setting up a persistent connection.  The default value is

--- a/default.migration_vars.yml
+++ b/default.migration_vars.yml
@@ -42,3 +42,9 @@ sunetid: ""
 # have at least one string resembling PHP.  Options include: fail or continue.
 # Example: fail
 php_candidates_consequence: "fail"
+
+# If your local drush alias prefixes are set to "ds_" for sites1/sites2 and
+# "dp_" for people1/people2, leave this set to "default". If you are NOT using
+# prefixes (e.g., you call "drush @sse.sitename" or "drush @ppl.sunetid"), then
+# set this to "".
+sites_drush_prefix: "default"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -28,3 +28,8 @@ stack_id: "2"
 sitefactory_environment: ""
 stanford_environment: ""
 drush_environment: ""
+
+# This variable (ignore_updb_errors should be set to an empty string by
+# defaults, in order to avoid "undefined variable" error messages. It can be
+# set on a per-site basis in the inventory file.
+ignore_updb_errors: ""

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -29,7 +29,7 @@ sitefactory_environment: ""
 stanford_environment: ""
 drush_environment: ""
 
-# This variable (ignore_updb_errors should be set to an empty string by
-# defaults, in order to avoid "undefined variable" error messages. It can be
-# set on a per-site basis in the inventory file.
+# This variable (ignore_updb_errors) should be set to an empty string by
+# default, in order to avoid "undefined variable" error messages. It can be
+# set on a per-site basis to "TRUE" in the inventory file. It is case-sensitive.
 ignore_updb_errors: ""

--- a/migration-playbook.yml
+++ b/migration-playbook.yml
@@ -37,9 +37,9 @@
     - { role: protect-prod }
     - { role: setup-local }
     - { role: download-site, tags: [download-site] }
+    - { role: setup-site, tags: [setup-site] }
     - { role: css-injector, tags: [download-site,css-injector] }
     - { role: check-php, tags: [download-site,css-injector,check-php] }
-    - { role: setup-site, tags: [download-site,check-php,setup-site] }
     - { role: upload-site, tags: [download-site,check-php,setup-site,upload-site] }
     - { role: change-paths, tags: [download-site,check-php,setup-site,upload-site,change-paths] }
     - { role: add-vhost, tags: [download-site,check-php,setup-site,upload-site,change-paths,get-sitename,add-vhost] }

--- a/roles/download-site/tasks/main.yml
+++ b/roles/download-site/tasks/main.yml
@@ -36,7 +36,7 @@
     sites_drush_alias: "{{ server_alias }}.{{ sites_drush_prefix }}{{ inventory_hostname }}"
   when: sites_drush_prefix != 'default'
 
-- name: Download copy of database from sites
+- name: Download copy of database from sites when using a custom drush prefix
   shell: "drush @{{ sites_drush_alias }} sql-dump --structure-tables-key=common > /tmp/{{ inventory_hostname }}/dbdump.sql"
   when: sites_drush_prefix != 'default'
 

--- a/roles/download-site/tasks/main.yml
+++ b/roles/download-site/tasks/main.yml
@@ -29,6 +29,16 @@
 
 - name: Download copy of database from sites
   shell: "drush @{{ server_alias }}.{{ site_prefix }}_{{ inventory_hostname }} sql-dump --structure-tables-key=common > /tmp/{{ inventory_hostname }}/dbdump.sql"
+  when: sites_drush_prefix == 'default'
+
+- name: Set sites drush alias
+  set_fact:
+    sites_drush_alias: "{{ server_alias }}.{{ sites_drush_prefix }}{{ inventory_hostname }}"
+  when: sites_drush_prefix != 'default'
+
+- name: Download copy of database from sites
+  shell: "drush @{{ sites_drush_alias }} sql-dump --structure-tables-key=common > /tmp/{{ inventory_hostname }}/dbdump.sql"
+  when: sites_drush_prefix != 'default'
 
 - name: Copy files from Sites to local
   shell: "rsync -avz {{ sunetid }}@{{ server }}.stanford.edu:/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/* /tmp/{{ inventory_hostname }}/files/."

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -40,9 +40,14 @@
     - "-y sql-drop"
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
     - "-y updb"
-    - "-y updb"
-  ignore_errors: "{% if ignore_updb_errors=='true' %}yes{% endif %}"
+  ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
   notify: Clear site cache
+
+- name: Run drush updb a second time for recalcitrant sites
+  shell: "{{drush_alias }} {{ item }}"
+  with_items:
+    - "-y updb"
+  when: ignore_updb_errors == "TRUE"
 
 - name: Set site up as a Department site
   shell: "{{drush_alias }} {{ item }}"

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -28,19 +28,23 @@
 # KNOWN ISSUES:
 # --
 
-# We sometimes have order-of-operation issues on drush updb.
-# For instance, a "Column not found: 1054 Unknown column 'base.status' in
-# 'field list'" error. Running "drush updb" twice allows us to get past that,
-# and we can set ignore_updb_errors="TRUE" in our inventory on a per-site
-# basis.
 - name: Drop database in Site Factory and install new database
   shell: "{{drush_alias }} {{ item }}"
   with_items:
     - "-y sql-drop"
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
+  notify: Clear site cache
+
+# We sometimes have order-of-operation issues on drush updb. For instance, a
+# "Column not found: 1054 Unknown column 'base.status' in 'field list'" error.
+# To get past that, we can set ignore_updb_errors="TRUE" in our inventory on a
+# per-site basis. That will allow us to move past errors in this task, and run
+# "drush updb" a second time in the following task.
+- name: Update database schema with drush updb
+  shell: "{{drush_alias }} {{ item }}"
+  with_items:
     - "-y updb"
   ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
-  notify: Clear site cache
 
 # This only runs "drush updb" if ignore_updb_errors == "TRUE"
 - name: Run drush updb a second time for recalcitrant sites

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -33,6 +33,7 @@
   with_items:
     - "-y sql-drop"
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
+    - "-y updb"
   notify: Clear site cache
 
 - name: Set site up as a Department site
@@ -50,7 +51,6 @@
 - name: Do post-database-restore tasks
   shell: "{{drush_alias }} {{ item }}"
   with_items:
-    - "-y updb"
     - "-y en acsf stanford_ssp paranoia"
     - "ev 'acsf_openid_allow_local_user_logins();'"
     - 'ev "_paranoia_remove_risky_permissions();"'

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -31,9 +31,8 @@
 # We sometimes have order-of-operation issues on drush updb.
 # For instance, a "Column not found: 1054 Unknown column 'base.status' in
 # 'field list'" error. Running "drush updb" twice allows us to get past that,
-# and we can set ignore_updb_errors="true" in our inventory on a per-site
+# and we can set ignore_updb_errors="TRUE" in our inventory on a per-site
 # basis.
-
 - name: Drop database in Site Factory and install new database
   shell: "{{drush_alias }} {{ item }}"
   with_items:
@@ -43,6 +42,7 @@
   ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
   notify: Clear site cache
 
+# This only runs "drush updb" if ignore_updb_errors == "TRUE"
 - name: Run drush updb a second time for recalcitrant sites
   shell: "{{drush_alias }} {{ item }}"
   with_items:

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -28,12 +28,20 @@
 # KNOWN ISSUES:
 # --
 
+# We sometimes have order-of-operation issues on drush updb.
+# For instance, a "Column not found: 1054 Unknown column 'base.status' in
+# 'field list'" error. Running "drush updb" twice allows us to get past that,
+# and we can set ignore_updb_errors="true" in our inventory on a per-site
+# basis.
+
 - name: Drop database in Site Factory and install new database
   shell: "{{drush_alias }} {{ item }}"
   with_items:
     - "-y sql-drop"
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
     - "-y updb"
+    - "-y updb"
+  ignore_errors: "{% if ignore_updb_errors=='true' %}yes{% endif %}"
   notify: Clear site cache
 
 - name: Set site up as a Department site


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Run `drush updb` immediately after restoring the DB
- Provide a method to run a second `drush updb` and ignore errors if a given site has troubles with the database update.

# Needed By (Date)
- The sooner this gets merged, the sooner we can merge socorro.

# Criticality
- How critical is this PR on a 1-10 scale? 3


# Steps to Test

1. Check out `master`
2. Clone https://github.com/SU-SWS/ansible-sync/ into your `ansible-playbooks` directory
3. Create a file in the `inventory` directory called `supri-b` with the following contents:
```
[earth]
supri-b vhost="supri-b"

[depts:children]
earth

[earth:vars]
group_ids=336
```
4. Obtain a Kerberos TGT
5. Run `ansible-playbook -i inventory/supri-b migration-playbook.yml`
6. Weep as you encounter a fatal error "Column not found: 1054 Unknown column 'base.status' in 'field list'"
7. Check out this branch
8. Update your `inventory/supri-b` file so that you have `supri-b vhost="supri-b" ignore_updb_errors="TRUE"`
9. Re-run the command from Step 5.
10. Rejoice
11. Optionally, run the command from Step 5 with `supri-b vhost="supri-b"` in your `inventory/supri-b` file. It probably will fail; it may not. Thus the purpose of this PR.

# Affected Projects or Products
- ACSF, socorro

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-530
- Other contextual information that might be helpful: The change in `migration-playbook.yml` simply moves the `setup-site` task earlier in the playbook. It is not functionally related to this PR, it was just something that I noticed. As long as it runs successfully, GTG.
- Related PR: #42 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)