### PR TITLE
SITES-225: Block acsf_openid module

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -28,3 +28,8 @@ stack_id: "2"
 sitefactory_environment: ""
 stanford_environment: ""
 drush_environment: ""
+
+# This variable (ignore_updb_errors should be set to an empty string by
+# defaults, in order to avoid "undefined variable" error messages. It can be
+# set on a per-site basis in the inventory file.
+ignore_updb_errors: ""

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -93,7 +93,7 @@
   with_items:
     - "-y en acsf acsf_helper stanford_ssp paranoia"
     - 'ev "_paranoia_remove_risky_permissions();"'
-    - "-y dis stanford_afs_quota acsf_openid"
+    - "-y dis stanford_afs_quota acsf_openid openid"
     # Must truncate this table otherwise users will lose roles in WMD->SSP upgrade path.
     - "sqlq 'truncate table webauth_roles_history'"
     - "sspwmd"

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -51,7 +51,6 @@
     - "cc all"
     - "sqlq 'update system set status=\"1\" where name=\"stanford_dept\"'"
     - "-y en acsf"
-    - "ev 'acsf_openid_allow_local_user_logins();'"
     - "rr"
   when: dept_site == "TRUE"
   notify: Clear site cache
@@ -59,10 +58,9 @@
 - name: Do post-database-restore tasks
   shell: "{{drush_alias }} {{ item }}"
   with_items:
-    - "-y en acsf stanford_ssp paranoia"
-    - "ev 'acsf_openid_allow_local_user_logins();'"
+    - "-y en acsf acsf_helper stanford_ssp paranoia"
     - 'ev "_paranoia_remove_risky_permissions();"'
-    - "-y dis stanford_afs_quota"
+    - "-y dis stanford_afs_quota acsf_openid"
     # Must truncate this table otherwise users will lose roles in WMD->SSP upgrade path.
     - "sqlq 'truncate table webauth_roles_history'"
     - "sspwmd"

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -33,6 +33,7 @@
   with_items:
     - "-y sql-drop"
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
+    - "-y updb"
   notify: Clear site cache
 
 - name: Set site up as a Department site
@@ -50,7 +51,6 @@
 - name: Do post-database-restore tasks
   shell: "{{drush_alias }} {{ item }}"
   with_items:
-    - "-y updb"
     - "-y en acsf stanford_ssp paranoia"
     - "ev 'acsf_openid_allow_local_user_logins();'"
     - 'ev "_paranoia_remove_risky_permissions();"'

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -84,12 +84,7 @@
     - "cc all"
     - "sqlq 'update system set status=\"1\" where name=\"stanford_dept\"'"
     - "-y en acsf"
-<<<<<<< HEAD
     - "rr"
-=======
-    - "ev 'acsf_openid_allow_local_user_logins();'"
-    - "-y rr"
->>>>>>> master
   when: dept_site == "TRUE"
   notify: Clear site cache
 

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -94,6 +94,8 @@
     - "-y en acsf acsf_helper stanford_ssp paranoia"
     - 'ev "_paranoia_remove_risky_permissions();"'
     - "-y dis stanford_afs_quota acsf_openid openid"
+    - "-y pm-uninstall stanford_afs_quota acsf_openid"
+    - "-y pm-uninstall openid"
     # Must truncate this table otherwise users will lose roles in WMD->SSP upgrade path.
     - "sqlq 'truncate table webauth_roles_history'"
     - "sspwmd"

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -28,12 +28,20 @@
 # KNOWN ISSUES:
 # --
 
+# We sometimes have order-of-operation issues on drush updb.
+# For instance, a "Column not found: 1054 Unknown column 'base.status' in
+# 'field list'" error. Running "drush updb" twice allows us to get past that,
+# and we can set ignore_updb_errors="true" in our inventory on a per-site
+# basis.
+
 - name: Drop database in Site Factory and install new database
   shell: "{{drush_alias }} {{ item }}"
   with_items:
     - "-y sql-drop"
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
     - "-y updb"
+    - "-y updb"
+  ignore_errors: "{% if ignore_updb_errors=='true' %}yes{% endif %}"
   notify: Clear site cache
 
 - name: Set site up as a Department site


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Disable `acsf_openid` during migration, so that sites that use local Drupal accounts can use them.

# Needed By (Date)
- Next week (week of July 16th) should be fine

# Criticality
- How critical is this PR on a 1-10 scale? 2/10
- Affects only one site as far as we know

# Steps to Test

1. Check out `master`
2. Clone `supri-b` to `dev` or `test`
3. Go to `affiliates/affiliate-program`
4. See no login link in the first sidebar
5. Check out this branch
6. Go to `affiliates/affiliate-program`
7. See the login link in the first sidebar
8. Optionally, create a local Drupal user account with the role "affiliate" and ensure that you can log in and see the affiliate links in the first sidebar

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules? ACSF

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-225

