### PR TITLE
Add a registry rebuild if drush updb pukes

### DIFF
--- a/group_vars/depts.yml
+++ b/group_vars/depts.yml
@@ -24,3 +24,7 @@ site_prefix: "ds"
 # Department sites get extra treatment during the migration process. Help us
 # skip this for non-department sites, by setting this value to FALSE.
 dept_site: "TRUE"
+#
+# Jumpstart product flag. Set this to true to have the script automagically
+# find and set the installation profile variable.
+product_site: "FALSE"

--- a/group_vars/groups.yml
+++ b/group_vars/groups.yml
@@ -24,3 +24,7 @@ site_prefix: "ds"
 # Department sites get extra treatment during the migration process. There shouldn't
 # be any department sites in the [groups] group, so this value should be set to FALSE.
 dept_site: "FALSE"
+#
+# Jumpstart product flag. Set this to true to have the script automagically
+# find and set the installation profile variable.
+product_site: "FALSE"

--- a/group_vars/people.yml
+++ b/group_vars/people.yml
@@ -28,3 +28,7 @@ site_prefix: "dp"
 # Department sites get extra treatment during the migration process. There shouldn't
 # be any department sites in the [people] group, so this value should be set to FALSE.
 dept_site: "FALSE"
+#
+# Jumpstart product flag. Set this to true to have the script automagically
+# find and set the installation profile variable.
+product_site: "FALSE"

--- a/group_vars/products.yml
+++ b/group_vars/products.yml
@@ -1,0 +1,30 @@
+# [depts] specific values for migration playbook.
+# https://github.com/SU-SWS/ansible-playbooks
+# ===============================================
+#
+# These values will be used when Ansible runs the migration playbook
+# against hosts listed under the [depts] inventory group.
+#
+# Enter the server from which we should pull the live site's database and
+# and files. Unless the sites are people sites, we'll probably want to
+# pull copies from `sites2`.
+server: "sites2"
+#
+# We'll be using drush aliases to download the live site's database and
+# files. Enter the alias we should be using for sites in this group. Unless
+# the sites are people sites, we'll probably want to use `sse`. People sites
+# should use `ppl`.
+server_alias: "sse"
+#
+# We had a convention on Stanford Sites of prefixing sitenames with `dp` for
+# people sites and `ds` for other types of sites. Enter which prefix we should
+# use for this in this group.
+site_prefix: "ds"
+#
+# Department sites get extra treatment during the migration process. Help us
+# skip this for non-department sites, by setting this value to FALSE.
+dept_site: "FALSE"
+#
+# Jumpstart product flag. Set this to true to have the script automagically
+# find and set the installation profile variable.
+product_site: "TRUE"

--- a/migration-playbook.yml
+++ b/migration-playbook.yml
@@ -26,7 +26,7 @@
 #
 # PLAY 1: Migrate sites from SWS infrastructure to Site Factory
 # =============================================================
-- hosts: groups,depts,people
+- hosts: groups,depts,people,products
   connection: local
 
   vars_files:

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -61,10 +61,22 @@
     - "-y updb"
   when: ignore_updb_errors == "TRUE"
 
+# Set the install profile by looking for the enabled supporting module.
+- name: Find and set the install profile by helper modules.
+  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; fi;"
+  with_items:
+    - { module: 'stanford_jumpstart', profile: 'stanford_sites_jumpstart' }
+    - { module: 'stanford_jumpstart_plus', profile: 'stanford_sites_jumpstart_plus' }
+    - { module: 'stanford_jumpstart_academic', profile: 'stanford_sites_jumpstart_academic' }
+    - { module: 'stanford_jumpstart_vpsa', profile: 'stanford_jumpstart_vpsa' }
+    - { module: 'stanford_jumpstart_lab', profile: 'stanford_sites_jumpstart_lab' }
+    - { module: 'stanford_jumpstart_engineering', profile: 'stanford_sites_jumpstart_engineering' }
+  when: product_site == "TRUE"
+
 - name: Set site up as a Department site
   shell: "{{ drush_alias }} {{ item }}"
   with_items:
-    - "-y vset install_profile stanford_sites_jumpstart"
+    - "-y vset install_profile stanford_dept"
     - "cc all"
     - "sqlq 'update system set status=\"1\" where name=\"stanford_dept\"'"
     - "-y en acsf"

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -52,6 +52,7 @@
   with_items:
     - "-y rr"
   when: ignore_updb_errors == "TRUE"
+  ignore_errors: yes
 
 # This only runs "drush updb" if ignore_updb_errors == "TRUE"
 - name: Run drush updb a second time for recalcitrant sites

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -62,6 +62,10 @@
   when: ignore_updb_errors == "TRUE"
 
 # Set the install profile by looking for the enabled supporting module.
+# Order of operations is important here, because a JSA site may have BOTH
+# "stanford_jumpstart" and "stanford_jumpstart_academic" enabled, yet we want
+# to be sure to set "install_profile" to "stanford_sites_jumpstart_academic" for
+# JSA sites (so that they get all the correct code).
 - name: Find and set the install profile by helper modules.
   shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; fi;"
   with_items:

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -44,8 +44,14 @@
   shell: "{{ drush_alias }} {{ item }}"
   with_items:
     - "-y updb"
-    - "-y rr"
   ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
+
+# This only runs "drush rr" if ignore_updb_errors == "TRUE"
+- name: Run drush rr before running drush updb a second time for recalcitrant sites
+  shell: "{{ drush_alias }} {{ item }}"
+  with_items:
+    - "-y rr"
+  when: ignore_updb_errors == "TRUE"
 
 # This only runs "drush updb" if ignore_updb_errors == "TRUE"
 - name: Run drush updb a second time for recalcitrant sites
@@ -57,12 +63,12 @@
 - name: Set site up as a Department site
   shell: "{{ drush_alias }} {{ item }}"
   with_items:
-    - "-y vset install_profile stanford_dept"
+    - "-y vset install_profile stanford_sites_jumpstart"
     - "cc all"
     - "sqlq 'update system set status=\"1\" where name=\"stanford_dept\"'"
     - "-y en acsf"
     - "ev 'acsf_openid_allow_local_user_logins();'"
-    - "rr"
+    - "-y rr"
   when: dept_site == "TRUE"
   notify: Clear site cache
 

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -41,20 +41,21 @@
 # per-site basis. That will allow us to move past errors in this task, and run
 # "drush updb" a second time in the following task.
 - name: Update database schema with drush updb
-  shell: "{{drush_alias }} {{ item }}"
+  shell: "{{ drush_alias }} {{ item }}"
   with_items:
     - "-y updb"
+    - "-y rr"
   ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
 
 # This only runs "drush updb" if ignore_updb_errors == "TRUE"
 - name: Run drush updb a second time for recalcitrant sites
-  shell: "{{drush_alias }} {{ item }}"
+  shell: "{{ drush_alias }} {{ item }}"
   with_items:
     - "-y updb"
   when: ignore_updb_errors == "TRUE"
 
 - name: Set site up as a Department site
-  shell: "{{drush_alias }} {{ item }}"
+  shell: "{{ drush_alias }} {{ item }}"
   with_items:
     - "-y vset install_profile stanford_dept"
     - "cc all"
@@ -66,7 +67,7 @@
   notify: Clear site cache
 
 - name: Do post-database-restore tasks
-  shell: "{{drush_alias }} {{ item }}"
+  shell: "{{ drush_alias }} {{ item }}"
   with_items:
     - "-y en acsf stanford_ssp paranoia"
     - "ev 'acsf_openid_allow_local_user_logins();'"

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -57,7 +57,6 @@
 - name: Run drush updb a second time for recalcitrant sites
   shell: "{{ drush_alias }} {{ item }}"
   with_items:
-    - "-y rr"
     - "-y updb"
   when: ignore_updb_errors == "TRUE"
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- TL;DR - what's this PR for? Rebuild the registry if our first `drush updb` fails

# Needed By (Date) Before we start migrating at scale

# Criticality
- How critical is this PR on a 1-10 scale? 6

# Steps to Test

1. Check out this branch
2. Add `jumpstart-sts vhost="sts"` to an inventory file (the group doesn't matter, you can add it in Earth or GSE from the last testing you did).
3. Clone to `dev`
4. Get a fatal class not defined error
5. Update your inventory entry to be `jumpstart-sts vhost="sts" ignore_updb_errors="TRUE"`
6. Re-run the migration
7. See it fail on the first `drush updb`, ignore the error, and then the second succeeds because we rebuilt the registry.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules? ACSF/Sites 2.0

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)