### PR TITLE
SITES-823: file_public_path variable is empty if site does not exist on ACSF

### DIFF
--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -95,16 +95,3 @@
 - name: Set drush alias
   set_fact:
     drush_alias: "drush @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}"
-
-- name: Get public files directory
-  shell: "{{ drush_alias }} status --fields='File directory path' --field-labels=0 --strict=0"
-  register: file_public_path
-
-- name: Print file_public_path
-  debug:
-    msg: "File public path: {{ file_public_path.stdout }}"
-
-- name: Be sure response does not include drush warnings
-  fail:
-    msg: "There appear to be drush warning messages cluttering the file_public_path variable"
-  when: file_public_path.stdout | search('The following module is missing')

--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -57,3 +57,16 @@
   delay: 50
   register: bootstrap_status
   until: bootstrap_status.stdout | search('Successful')
+
+- name: Get public files directory
+  shell: "{{ drush_alias }} status --fields='File directory path' --field-labels=0 --strict=0"
+  register: file_public_path
+
+- name: Print file_public_path
+  debug:
+    msg: "File public path: {{ file_public_path.stdout }}"
+
+- name: Be sure response does not include drush warnings
+  fail:
+    msg: "There appear to be drush warning messages cluttering the file_public_path variable"
+  when: file_public_path.stdout | search('The following module is missing')


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- We need the path to the public files directory to do database and CSS Injector surgery. With the current order-of-operations, this variable is empty if the site does not exist yet on ACSF. This PR fixes that.

# Needed By (Date)
- Wednesday, August 13.

# Criticality
- How critical is this PR on a 1-10 scale? 4/10 it's causing some issues for HSDO

# Steps to Test

1. Delete the `religiousstudies` site on `test`
2. Check out this branch
3. Migrate `religious-studies` to `test
4. Verify that you have an image of Tristan at https://religiousstudies-test.cardinalsites.stanford.edu/undergraduate/meet-your-peer-advisor-tristan-navarro

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules? ACSF

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-823

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)