### PR TITLE
SITES-566: randomize user1 password

### DIFF
--- a/default.migration_vars.yml
+++ b/default.migration_vars.yml
@@ -48,3 +48,8 @@ php_candidates_consequence: "fail"
 # prefixes (e.g., you call "drush @sse.sitename" or "drush @ppl.sunetid"), then
 # set this to "".
 sites_drush_prefix: "default"
+
+# Print out various debug messages. Set to FALSE by default; you can set it to
+# TRUE in migration_vars.yml, or set it at runtime with
+# --extra-vars "print_debug_messages=TRUE"
+print_debug_messages: "FALSE"

--- a/roles/add-vhost/tasks/main.yml
+++ b/roles/add-vhost/tasks/main.yml
@@ -26,9 +26,10 @@
 # KNOWN ISSUES:
 # --
 
-# - name: Debug new_absolute_path
-#   debug:
-#     var: new_absolute_path
+- name: Debug new_absolute_path
+  debug:
+    var: new_absolute_path
+  when: print_debug_messages == "TRUE"
 
 - name: Add custom domain
   uri:

--- a/roles/css-injector/tasks/main.yml
+++ b/roles/css-injector/tasks/main.yml
@@ -76,6 +76,7 @@
 - name: Debug CSS Injector files variable
   debug:
     msg: "CSS Injector files: {{ css_injector_files.files }}"
+  when: print_debug_messages == "TRUE"
 
 # 1
 # See https://docs.ansible.com/ansible/latest/modules/replace_module.html

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -48,6 +48,7 @@
 - name: What is the scripts_dir variable
   debug:
     msg: "scripts_dir is: {{ scripts_dir}}"
+  when: print_debug_messages == "TRUE"
 
 # Ex: g2sc.stanford.edu
 # Found example of a site with a vhost, hard linking to images by non-vhost path.
@@ -86,6 +87,7 @@
 - name: Debug absolute path for site
   debug:
     msg: "Absolute path: {{ new_absolute_path }}"
+  when: print_debug_messages == "TRUE"
 
 # Ex: drush @acsf.dev.cardinald7.g2scd7
 - name: Set drush alias

--- a/roles/get-public-files-path/tasks/main.yml
+++ b/roles/get-public-files-path/tasks/main.yml
@@ -26,6 +26,7 @@
 - name: Print file_public_path
   debug:
     msg: "File public path: {{ file_public_path.stdout }}"
+  when: print_debug_messages == "TRUE"
 
 - name: Be sure response does not include drush warnings
   fail:

--- a/roles/get-sitename/tasks/main.yml
+++ b/roles/get-sitename/tasks/main.yml
@@ -139,9 +139,10 @@
 # The array will be output in alphabetical order (id, site, url), but as the keys
 # are object properties, the order does not matter.
 #
-# - name: debug sites_formatted
-#   debug:
-#     var: sites_formatted
+- name: debug sites_formatted
+  debug:
+    var: sites_formatted
+  when: print_debug_messages == "TRUE"
 
 #
 # Now that we have a list of canonical machine names and ids in an ansible dict
@@ -156,9 +157,10 @@
   vars:
     existing_sites_query: "[?site=='{{ acsf_site_name }}'].id"
 
-# - name: debug possible_site_ids
-#   debug:
-#     var: possible_site_ids
+- name: debug possible_site_ids
+  debug:
+    var: possible_site_ids
+  when: print_debug_messages == "TRUE"
 
 #
 # If we did find a site then grab the id for use later.
@@ -168,10 +170,12 @@
     site_id: "{{ possible_site_ids|first }}"
   when: possible_site_ids|length > 0
 
-# - name: Debug site_id
-#   debug:
-#     var: site_id
-#
-# - name: Acsf site name
-#   debug:
-#     var: acsf_site_name
+- name: Debug site_id
+  debug:
+  var: site_id
+  when: print_debug_messages == "TRUE"
+
+- name: Acsf site name
+  debug:
+    var: acsf_site_name
+  when: print_debug_messages == "TRUE"

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -110,8 +110,6 @@
   notify: Clear site cache
 
 - name: Generate random password
-#  shell: "cat /dev/urandom | tr -cd a-zA-Z0-9_+=* | fold -w18 | head -n 1"
-#  register: random_pw
 # See https://stackoverflow.com/a/45080709
   set_fact:
     random_pw: "{{ 999999999999999999999 | random | string + (lookup('pipe', 'date +%s%N')) | to_uuid() }}"

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -68,7 +68,7 @@
   when: dept_site == "TRUE"
   notify: Clear site cache
 
-- name: Set Certs Dir
+- name: Set SimpleSAMLphp Certs Dir
   set_fact:
     certs_dir: "/mnt/www/html/{{ stack }}.02{% if acsf_environment=='' %}live{% elif acsf_environment=='test'%}test{% elif acsf_environment=='dev'%}dev{% endif %}/simplesamlphp/cert/"
 
@@ -108,3 +108,18 @@
 - name: Copy private files from local to Site Factory
   shell: "drush -y rsync /tmp/{{ inventory_hostname }}/files/private/ @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}:%private/"
   notify: Clear site cache
+
+- name: Generate random password
+#  shell: "cat /dev/urandom | tr -cd a-zA-Z0-9_+=* | fold -w18 | head -n 1"
+#  register: random_pw
+# See https://stackoverflow.com/a/45080709
+  set_fact:
+    random_pw: "{{ 999999999999999999999 | random | string + (lookup('pipe', 'date +%s%N')) | to_uuid() }}"
+
+- name: Debug random password
+  debug:
+    var: random_pw
+  when: print_debug_messages == "TRUE"
+
+- name: Randomize User 1 password
+  shell: "{{ drush_alias }} user-password 1 --password=\"{{ random_pw }}\""

--- a/roles/setup-local/templates/acsf.aliases.drushrc.php
+++ b/roles/setup-local/templates/acsf.aliases.drushrc.php
@@ -119,3 +119,14 @@ $aliases["dev." . $stack . "." . $site] = array(
     '%drush-script' => 'drush' . $drush_major_version,
   )
 );
+
+// Custom aliases to get around issue with periods.
+$aliases['sse.ds_dhminor.stanford.edu'] = array(
+  'remote-host' => "sites2.stanford.edu",
+  'remote-user' => $remote_user,
+  'root' => '/var/www/ds_dhminor.stanford.edu/public_html',
+  'uri' => "https://sites.stanford.edu/dhminor.stanford.edu",
+  'path-aliases' => array(
+    '%dump-dir' => '/afs/ir/group/webservices/tmp',
+  ),
+);

--- a/roles/setup-local/templates/acsf.aliases.drushrc.php
+++ b/roles/setup-local/templates/acsf.aliases.drushrc.php
@@ -119,14 +119,3 @@ $aliases["dev." . $stack . "." . $site] = array(
     '%drush-script' => 'drush' . $drush_major_version,
   )
 );
-
-// Custom aliases to get around issue with periods.
-$aliases['sse.ds_dhminor.stanford.edu'] = array(
-  'remote-host' => "sites2.stanford.edu",
-  'remote-user' => $remote_user,
-  'root' => '/var/www/ds_dhminor.stanford.edu/public_html',
-  'uri' => "https://sites.stanford.edu/dhminor.stanford.edu",
-  'path-aliases' => array(
-    '%dump-dir' => '/afs/ir/group/webservices/tmp',
-  ),
-);

--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -49,9 +49,10 @@
     site_exists: FALSE
   when: search_for_site|length == 0
 
-#- name: debug
-#  debug:
-#    var: site_exists
+- name: debug
+  debug:
+    var: site_exists
+  when: print_debug_messages == "TRUE"
 
 - name: Create new site on Site Factory
   uri:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Randomize User 1 password on migration
- Set `debug` statements to output conditionally based on a variable

# Needed By (Date)
- Before we do large-scale migrations

# Criticality
- How critical is this PR on a 1-10 scale? 4/10
- Affects every site

# Steps to Test

1. Set the password of User 1 to a known value on a Sites or people site
2. Migrate it to `test` or `dev`
3. Verify that you *can* log in with `admin/<password>` on ACSF
4. Check out this branch
5. Add `print_debug_messages: "FALSE"` to `migration_vars.yml`
6. Migrate the same site
7. Verify that you can *not* log in with `admin/<password>` on ACSF
8. Re-run the migration and pass `--extra-vars "print_debug_messages=TRUE"` on the command line
9. Verify that debug messages are output (e.g., the `random_pw` variable is output in the "Debug random password" task

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-566
- Other PRs: #53 
- Any other contextual information that might be helpful: I based this off of the `SITES-843...` branch, because we do need that functionality merged in.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)