### PR TITLE
SITES-723: Create alternate tasks for when AFS is available

### DIFF
--- a/default.migration_vars.yml
+++ b/default.migration_vars.yml
@@ -53,3 +53,8 @@ sites_drush_prefix: "default"
 # TRUE in migration_vars.yml, or set it at runtime with
 # --extra-vars "print_debug_messages=TRUE"
 print_debug_messages: "FALSE"
+
+#
+# Enable direct AFS access when running ansible on an AFS ready environment.
+# Example: TRUE
+afs_available: "FALSE"

--- a/roles/css-injector/tasks/main.yml
+++ b/roles/css-injector/tasks/main.yml
@@ -69,7 +69,7 @@
 
 - name: Get list of CSS Injector files
   find:
-    paths: /tmp/{{ inventory_hostname }}/files/css_injector/
+    paths: "{% if afs_available == "TRUE" %}/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}{% else %}/tmp/{{ inventory_hostname }}{% endif %}/files/css_injector/"
     patterns: "*.css"
   register: css_injector_files
 

--- a/roles/css-injector/tasks/main.yml
+++ b/roles/css-injector/tasks/main.yml
@@ -69,7 +69,7 @@
 
 - name: Get list of CSS Injector files
   find:
-    paths: "{% if afs_available == "TRUE" %}/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}{% else %}/tmp/{{ inventory_hostname }}{% endif %}/files/css_injector/"
+    paths: "{% if afs_available == 'TRUE' %}/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}{% else %}/tmp/{{ inventory_hostname }}{% endif %}/files/css_injector/"
     patterns: "*.css"
   register: css_injector_files
 

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -43,7 +43,7 @@
 # Ex. /var/www/html/cardinald7.02dev/scripts
 - name: Set scripts_dir variable
   set_fact:
-    scripts_dir: "/var/www/html/{{ stack }}.0{{ stack_id }}{% if acsf_environment=='' %}live{% elif acsf_environment=='test'%}test{% elif acsf_environment=='dev'%}dev{% endif %}/scripts"
+    scripts_dir: "/var/www/html/{{ stack }}.0{{ stack_id }}{% if acsf_environment=='' %}live{% elif acsf_environment=='test'%}test{% elif acsf_environment=='dev' %}dev{% endif %}/scripts"
 
 - name: What is the scripts_dir variable
   debug:

--- a/roles/define-paths/tasks/main.yml
+++ b/roles/define-paths/tasks/main.yml
@@ -43,7 +43,7 @@
 # Ex. /var/www/html/cardinald7.02dev/scripts
 - name: Set scripts_dir variable
   set_fact:
-    scripts_dir: "/var/www/html/{{ stack }}.0{{ stack_id }}{% if acsf_environment=='' %}live{% elif acsf_environment=='test'%}test{% elif acsf_environment=='dev' %}dev{% endif %}/scripts"
+    scripts_dir: "/var/www/html/{{ stack }}.0{{ stack_id }}{% if acsf_environment=='' %}live{% elif acsf_environment=='test' %}test{% elif acsf_environment=='dev' %}dev{% endif %}/scripts"
 
 - name: What is the scripts_dir variable
   debug:

--- a/roles/download-site/tasks/main.yml
+++ b/roles/download-site/tasks/main.yml
@@ -42,3 +42,5 @@
 
 - name: Copy files from Sites to local
   shell: "rsync -avz {{ sunetid }}@{{ server }}.stanford.edu:/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/* /tmp/{{ inventory_hostname }}/files/."
+  when:
+    afs_available != "TRUE"

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -114,15 +114,15 @@
     afs_available != "TRUE"
 
 # Copy public files from AFS so that they exist and Drupal can find them if needed
-- name: Copy public files from local to Site Factory
-  shell: "drush -y rsync /afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/* @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}:%files/ --exclude-paths=sites/default/files/js_injector/"
+- name: Copy public files from AFS to Site Factory
+  shell: "drush -y rsync '/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/' @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}:%files/ --exclude-paths=sites/default/files/js_injector/"
   notify: Clear site cache
   when:
     afs_available == "TRUE"
 
 # Copy private files from AFS so that they exist and Drupal can find them if needed
-- name: Copy private files from local to Site Factory
-  shell: "drush -y rsync /afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/private/* @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}:%private/"
+- name: Copy private files from AFS to Site Factory
+  shell: "drush -y rsync '/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/private/' @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}:%private/"
   notify: Clear site cache
   when:
     afs_available == "TRUE"

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -70,7 +70,7 @@
 
 - name: Set SimpleSAMLphp Certs Dir
   set_fact:
-    certs_dir: "/mnt/www/html/{{ stack }}.02{% if acsf_environment=='' %}live{% elif acsf_environment=='test'%}test{% elif acsf_environment=='dev'%}dev{% endif %}/simplesamlphp/cert/"
+    certs_dir: "/mnt/www/html/{{ stack }}.02{% if acsf_environment=='' %}live{% elif acsf_environment=='test' %}test{% elif acsf_environment=='dev' %}dev{% endif %}/simplesamlphp/cert/"
 
 - name: Do post-database-restore tasks
   shell: "{{ drush_alias }} {{ item }}"

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -99,15 +99,33 @@
   when: launch_tasks == ""
   notify: Clear site cache
 
-# Copy public files first so that they exist and Drupal can find them if needed
+# Copy public files so that they exist and Drupal can find them if needed
 - name: Copy public files from local to Site Factory
   shell: "drush -y rsync /tmp/{{ inventory_hostname }}/files/ @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}:%files/ --exclude-paths=sites/default/files/js_injector/"
   notify: Clear site cache
+  when:
+    afs_available != "TRUE"
 
-# Copy private files first so that they exist and Drupal can find them if needed
+# Copy private files so that they exist and Drupal can find them if needed
 - name: Copy private files from local to Site Factory
   shell: "drush -y rsync /tmp/{{ inventory_hostname }}/files/private/ @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}:%private/"
   notify: Clear site cache
+  when:
+    afs_available != "TRUE"
+
+# Copy public files from AFS so that they exist and Drupal can find them if needed
+- name: Copy public files from local to Site Factory
+  shell: "drush -y rsync /afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/* @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}:%files/ --exclude-paths=sites/default/files/js_injector/"
+  notify: Clear site cache
+  when:
+    afs_available == "TRUE"
+
+# Copy private files from AFS so that they exist and Drupal can find them if needed
+- name: Copy private files from local to Site Factory
+  shell: "drush -y rsync /afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/private/* @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}:%private/"
+  notify: Clear site cache
+  when:
+    afs_available == "TRUE"
 
 - name: Generate random password
 # See https://stackoverflow.com/a/45080709


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Eke out some performance gains if AFS is available.

# Needed By (Date)
- September 7th?

# Criticality
- How critical is this PR on a 1-10 scale? 3/10
- Only really applicable to very large sites
- See performance metrics at https://stanfordits.atlassian.net/browse/SITES-723

# Steps to Test

1. Check out this branch
2. Set `afs_available = "TRUE"` in `migration_vars.yml`
3. Migrate `sws-migration-testing vhost="sws-oddball-vhost"
4. Verify that the images on the homepage copied
5. Verify that the images at `/css` copied and are loading
6. Verify that the images at `/js` copied and are loading
7. Verify that the replacements ran for `admin/config/development/js-injector/list/js_migration_test/edit`
8. Verify that the replacements ran for `admin/config/development/css-injector/edit/2`

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-690

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)