### PR TITLE
SITES-907: Add missing tasks for css-injector 

### DIFF
--- a/migration-sync-only-playbook.yml
+++ b/migration-sync-only-playbook.yml
@@ -36,6 +36,7 @@
   roles:
     - { role: setup-local }
     - { role: download-site }
+    - { role: get-sitename }
     - { role: css-injector }
     - { role: check-php }
     - { role: upload-site }

--- a/migration-sync-only-playbook.yml
+++ b/migration-sync-only-playbook.yml
@@ -36,7 +36,6 @@
   roles:
     - { role: setup-local }
     - { role: download-site }
-    - { role: get-sitename }
     - { role: css-injector }
     - { role: check-php }
     - { role: upload-site }

--- a/roles/get-sitename/tasks/main.yml
+++ b/roles/get-sitename/tasks/main.yml
@@ -128,7 +128,7 @@
 #
 - name: Manipulate sites.json
   set_fact:
-    sites_formatted: "{{ sites_formatted|default([]) + [ {'url': item.0, 'id': sites_json.sites[item.0].conf.acsf_site_id, 'site': item.0|regex_replace('.(dev-|test-)cardinalsites.acsitefactory.com', '') } ] }}"
+    sites_formatted: "{{ sites_formatted|default([]) + [ {'url': item.0, 'id': sites_json.sites[item.0].conf.acsf_site_id, 'site': item.0|regex_replace('.(dev-|test-|)cardinalsites.acsitefactory.com', '') } ] }}"
   with_together:
     - "{{ sites_json.sites }}"
     - "{{ sites_json.sites }}"
@@ -155,7 +155,7 @@
   set_fact:
     possible_site_ids: "{{ sites_formatted|json_query(existing_sites_query) }}"
   vars:
-    existing_sites_query: "[?site=='{{ acsf_site_name }}'].id"
+    existing_sites_query: "[?site=='{{ acsf_site_name|lower }}'].id"
 
 - name: debug possible_site_ids
   debug:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add get-sitename task to sync only so that the site_id variable is available in the clear cache function for css-injector.

# Needed By (Date)
- Seems to work without it but the cache clear might fail.

# Urgency
- Low

# Steps to Test

1. Migrate pulse to production

# Affected Projects or Products
- ?

# Associated Issues and/or People
- SITES-907

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)