### PR TITLE
SITES-825: Run drush rr immediately after importing the DB.

### DIFF
--- a/roles/get-sitename/tasks/main.yml
+++ b/roles/get-sitename/tasks/main.yml
@@ -87,9 +87,10 @@
   when:
     sites_service == "people"
 
-# - name: debug sites.json
-#   debug:
-#     var: sites_json
+- name: debug sites.json
+  debug:
+    var: sites_json
+  when: print_debug_messages == "TRUE"
 
 #
 # Creates a format that looks like:

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -35,7 +35,7 @@
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
   notify: Clear site cache
 
-# BEANS FEEDS and probably bears too.,
+# BEANS, FEEDS, and probably bears too!
 # The change in where the entity class exists can cause fatal errors and not
 # allow the rest to continue. This drush rr is to ensure that all the PHP
 # classes are registered and in the right place before we try to run updates.

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -41,6 +41,7 @@
 # before we try to update.
 - name: Run drush rr before running anything else
   shell: "{{ drush_alias }} {{ item }}"
+  ignore_errors: yes
   with_items:
     - "-y rr"
 

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -35,6 +35,15 @@
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
   notify: Clear site cache
 
+# BEANS BEANS BEANS,
+# The change in the entity class can cause fatal errors and not allow the rest
+# to continue. This is to ensure that all the parts are in the right place
+# before we try to update.
+- name: Run drush rr before running anything else
+  shell: "{{ drush_alias }} {{ item }}"
+  with_items:
+    - "-y rr"
+
 # We sometimes have order-of-operation issues on drush updb. For instance, a
 # "Column not found: 1054 Unknown column 'base.status' in 'field list'" error.
 # To get past that, we can set ignore_updb_errors="TRUE" in our inventory on a

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -35,10 +35,10 @@
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
   notify: Clear site cache
 
-# BEANS BEANS BEANS,
-# The change in the entity class can cause fatal errors and not allow the rest
-# to continue. This is to ensure that all the parts are in the right place
-# before we try to update.
+# BEANS FEEDS and probably bears too.,
+# The change in where the entity class exists can cause fatal errors and not
+# allow the rest to continue. This drush rr is to ensure that all the PHP
+# classes are registered and in the right place before we try to run updates.
 - name: Run drush rr before running anything else
   shell: "{{ drush_alias }} {{ item }}"
   ignore_errors: yes

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -39,11 +39,12 @@
 # The change in where the entity class exists can cause fatal errors and not
 # allow the rest to continue. This drush rr is to ensure that all the PHP
 # classes are registered and in the right place before we try to run updates.
-- name: Run drush rr before running anything else
+- name: Run drush rr before running anything else if we're having issues
   shell: "{{ drush_alias }} {{ item }}"
   ignore_errors: yes
   with_items:
     - "-y rr"
+  ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
 
 # We sometimes have order-of-operation issues on drush updb. For instance, a
 # "Column not found: 1054 Unknown column 'base.status' in 'field list'" error.
@@ -70,3 +71,10 @@
   with_items:
     - "-y updb"
   when: ignore_updb_errors == "TRUE"
+
+# Rebuild the registry on all sites
+- name: Rebuild the registry after updating the database schema
+  shell: "{{ drush_alias }} {{ item }}"
+  ignore_errors: yes
+  with_items:
+    - "-y rr"


### PR DESCRIPTION
# READY FOR REVIEW/NOT READY
- (Edit the above to reflect status)

# Summary
- Ensures that all PHP classes are registered to Drupal
- Ensures that all update hooks are found in new & old modules
- Ensures that modules that no longer exist are dropped from the registry as they may have an impact.

# Needed By (Date)
- Before migrating Iranian-studies

# Urgency
-  Medium

# Steps to Test

1. Check out this branch
2. Ensure the dev environment on acsf has the fix for guuid updates in capx.
3. migrate iranian-studies to dev

# Associated Issues and/or People
- SITES-825

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)