### PR TITLE
SITES-916: Put sites in maintenance mode for final cutover

### DIFF
--- a/roles/change-paths/tasks/main.yml
+++ b/roles/change-paths/tasks/main.yml
@@ -193,3 +193,10 @@
 - name: Save modified JS Injector rules to disk
   shell: "{{ drush_alias }} scr {{ scripts_dir }}/js-injector.php"
   notify: Clear site cache
+
+# Bring 'er out of hyperspace, Chewy
+- name: Turn off maintenance mode for Sites 1.x site and ACSF site
+  shell: "{{ item }} -y --exact vset maintenance_mode 0"
+  with_items:
+    - " {{ drush_alias }}"
+    - " drush @{{ server_alias }}.{{ site_prefix }}_{{ inventory_hostname }} "

--- a/roles/download-site/tasks/main.yml
+++ b/roles/download-site/tasks/main.yml
@@ -27,6 +27,14 @@
 # KNOWN ISSUES:
 # --
 
+- name: Put Sites 1.x site and ACSF site in maintenance mode for final pre-launch migration
+  shell: "{{ item }} -y --exact vset maintenance_mode 1"
+  with_items:
+    - " {{ drush_alias }}"
+    - " drush @{{ server_alias }}.{{ site_prefix }}_{{ inventory_hostname }} "
+  when:
+    launch_tasks == "launch"
+
 - name: Download copy of database from sites
   shell: "drush @{{ server_alias }}.{{ site_prefix }}_{{ inventory_hostname }} sql-dump --structure-tables-key=common > /tmp/{{ inventory_hostname }}/dbdump.sql"
   when: sites_drush_prefix == 'default'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Put both the Sites website and the ACSF website into maintenance mode while content migration is underway
- Take them out when finished

# Needed By (Date)
- 9.28.18

# Criticality
- How critical is this PR on a 1-10 scale? 5/10

# Steps to Test

1. Check out this branch
2. Run `full-migration-playbook.yml` on a site
3. Once it gets to the beginning of the `download-site` role, check that both the Sites (or People) site *and* the ACSF site are in maintenance mode
4. Once it gets to the end of the `change-paths` role, verify that both the Sites (or People) site *and* the ACSF site are out of maintenance mode
5. Run `migration-sync-only-playbook.yml` on the same site
6. Repeat steps 3 and 4

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-916

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)