### PR TITLE
Check if site exist fails if Drupal has PHP error or database is empty

### DIFF
--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -75,11 +75,11 @@
     minutes: 1
 
 - name: Check drush can bootstrap site
-  shell: "{{ drush_alias }} status --fields='Drupal bootstrap' --field-labels=0 --strict=0"
+  shell: "{{ drush_alias }} status"
   retries: "{{ wait_time }}"
   delay: 50
   register: bootstrap_status
-  until: bootstrap_status.stdout is search('Successful')
+  until: bootstrap_status.stdout is search('Database name')
 
 - name: Re-call the sites-json stuff
   include_role:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Whenever a site fails to install or if there is a PHP error, the `drush st` check fails to assert that the site exists. When migrating to the ACSF environment we drop the database right away anyhow so no need to bootstrap Drupal. Just check if all the parts are there.

# Needed By (Date)
- I run into this all the time testing migrations that already exist that have failed.

# Urgency
- Low

# Steps to Test

1. Check out this branch
2. Drop the database on iranianstudies dev (drush @acsf.dev.cardinald7.iranianstudies sql-drop)
3. Run full migration playbook using iranian-studies as your inventory item
4. Truncate the `system` table
5. Run `migration-sync-only-playbook.yml`

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)