### PR TITLE
Fix logic to create site on ACSF if it does not exist

### DIFF
--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -58,7 +58,7 @@
     body_format: json
     return_content: yes
   register: site_created
-  when: not site_exists
+  when: site_exists == "FALSE"
 
 - pause:
     minutes: 1

--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -73,4 +73,4 @@
 - name: Re-call the sites-json stuff
   include_role:
     name: get-sitename
-  when: not site_exists
+  when: sites_exists = "FALSE"

--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -74,4 +74,4 @@
 - name: Re-call the sites-json stuff
   include_role:
     name: get-sitename
-  when: site_exists = "FALSE"
+  when: site_exists == "FALSE"

--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -23,6 +23,7 @@
 # OUTPUTS:
 #   bootstrap_status
 #   site_created
+#   site_exists
 #
 # ALTERNATIVE ROLES:
 # --
@@ -73,4 +74,4 @@
 - name: Re-call the sites-json stuff
   include_role:
     name: get-sitename
-  when: sites_exists = "FALSE"
+  when: site_exists = "FALSE"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- **Update:** See #63 
- In #62, we changed the way that we determined whether a site exists or not from `sites.json`. The conditional to create a new site if it does not exist now is flawed.

# Needed By (Date)
- Soonish, although not highly critical because we have all of our "people" sites created on prod already

# Criticality
- How critical is this PR on a 1-10 scale? 4/10
- Affects any sites that we want to create on ACSF that don't already exist.

# Steps to Test

1. Pick a site to migrate to `dev` or `test`
2. Delete the site on that environment
3. Run `full-migration-playbook.yml` using the `master` branch
4. See that the "Create new site on Site Factory" task is skipped
5. Note that the playbook fails to advance, because there's no site there.
6. Check out this branch.
7. Run `full-migration-playbook.yml`
8. Success

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- Other PRs: #62 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)