### PR TITLE
SITES-965: Add cache-per-host to Ansible setup-server role

### DIFF
--- a/roles/setup-server/templates/.bashrc
+++ b/roles/setup-server/templates/.bashrc
@@ -1,1 +1,7 @@
 alias ll='ls -alhF'
+
+# Environment variables are different to drush than when signed in.
+WEBHEAD=$(hostname | cut -d'.' -f 1);
+export WEBHEAD
+CACHE_PREFIX=/home/leland/.drush/$WEBHEAD
+export CACHE_PREFIX


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allows us to track the cache-per-host changes to `~/.bashrc` in this repo, and re-apply that setting if the file gets blown away

# Needed By (Date)
- Whenevah

# Criticality
- How critical is this PR on a 1-10 scale? 1/10

# Steps to Test

1. Delete `~/.bashrc` on a host
2. Run `server-settings-playbook.yml` (LMK if you need an inventory)
3. Verify that the `~./bashrc` looks like this:
```
alias ll='ls -alhF'

# Environment variables are different to drush than when signed in.
WEBHEAD=$(hostname | cut -d'.' -f 1);
export WEBHEAD
CACHE_PREFIX=/home/leland/.drush/$WEBHEAD
export CACHE_PREFIX
```

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-965

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)