### PR TITLE
SITES-980: grep for sites in sites.json is not precise enough

### DIFF
--- a/roles/sites-json/tasks/main.yml
+++ b/roles/sites-json/tasks/main.yml
@@ -42,7 +42,7 @@
 # "sitename.cardinalsites.acsitefactory.com" is the canonical name for a given
 # site. Grep for that and output it to a file.
 - name: Grep sites.json file for our sitename
-  shell: "grep {{ acsf_site_name }}.{{ sitefactory_environment }}cardinalsites.acsitefactory.com /tmp/{{ inventory_hostname }}/sites.json > /tmp/{{ inventory_hostname }}/sites_json_raw"
+  shell: "grep '\"{{ acsf_site_name }}.{{ sitefactory_environment }}cardinalsites.acsitefactory.com' /tmp/{{ inventory_hostname }}/sites.json > /tmp/{{ inventory_hostname }}/sites_json_raw"
   ignore_errors: yes
 
 # sites_json_raw will be a really long string like this:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Bug fix where two sites ending in the same string would get conflated.

# Needed By (Date)
- Eh. Soonish.

# Criticality
- How critical is this PR on a 1-10 scale? 3/10
- Unsure how wide the scope is, but we've already hit conflicts with biology/paleobiology

# Steps to Test

1. Check out `master`
2. Create two sites on `dev` that end in the same string (e.g., "foo" and "ohzeefoo")
3. Add them to an inventory and run `post-db-restore-playbook.yml` with `print_debug_messages: "TRUE"` (that will let you see the `site_id`)
4. Fail
5. Check out this branch
6. Repeat step 3
7. Rejoice

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-980
- Any other contextual information that might be helpful: This rivals the "one pipe" pull request for smallest oversight

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)