### PR TITLE
SITES-000 and SITES-695

### DIFF
--- a/acsf-site-setup-playbook.yml
+++ b/acsf-site-setup-playbook.yml
@@ -36,6 +36,7 @@
   roles:
     - { role: get-sitename }
     - { role: protect-prod }
+    - { role: setup-local }
     - { role: setup-site }
     - { role: add-vhost }
   serial: 12

--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -65,13 +65,13 @@
     minutes: 1
 
 - name: Check drush can bootstrap site
-  shell: "{{ drush_alias }} status"
+  shell: "{{ drush_alias }} status --fields='Drupal bootstrap' --field-labels=0 --strict=0"
   retries: "{{ wait_time }}"
   delay: 50
   register: bootstrap_status
-  until: bootstrap_status.stdout is search('Database name')
+  until: bootstrap_status.stdout is search('Successful')
 
 - name: Re-call the sites-json stuff
   include_role:
-    name: get-sitename
+    name: sites-json
   when: site_exists == "FALSE"

--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -64,13 +64,6 @@
 - pause:
     minutes: 1
 
-#- name: Check drush can bootstrap site
-#  shell: "{{ drush_alias }} status --fields='Drupal bootstrap' --field-labels=0 --strict=0"
-#  retries: "{{ wait_time }}"
-#  delay: 50
-#  register: bootstrap_status
-#  until: bootstrap_status.stdout is search('Successful')
-
 - name: Re-call the sites-json stuff
   include_role:
     name: sites-json

--- a/roles/setup-site/tasks/main.yml
+++ b/roles/setup-site/tasks/main.yml
@@ -64,14 +64,29 @@
 - pause:
     minutes: 1
 
-- name: Check drush can bootstrap site
-  shell: "{{ drush_alias }} status --fields='Drupal bootstrap' --field-labels=0 --strict=0"
-  retries: "{{ wait_time }}"
-  delay: 50
-  register: bootstrap_status
-  until: bootstrap_status.stdout is search('Successful')
+#- name: Check drush can bootstrap site
+#  shell: "{{ drush_alias }} status --fields='Drupal bootstrap' --field-labels=0 --strict=0"
+#  retries: "{{ wait_time }}"
+#  delay: 50
+#  register: bootstrap_status
+#  until: bootstrap_status.stdout is search('Successful')
 
 - name: Re-call the sites-json stuff
   include_role:
     name: sites-json
+  when: site_exists == "FALSE"
+
+- name: Check that site is available
+  uri:
+    url: "https://www.{{ sitefactory_environment }}cardinalsites.acsitefactory.com/api/v1/sites/{{ site_id }}"
+    method: GET
+    user: "{{ acquia_username }}"
+    password: "{{ acquia_api_key }}"
+    force_basic_auth: yes
+    body_format: json
+    return_content: yes
+  retries: "{{ wait_time }}"
+  delay: 50
+  register: site_created
+  until: site_created is not failed
   when: site_exists == "FALSE"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Running `acsf-site-setup-playbook.yml` fails because the `site_id` variable is not populated
- `acsf-site-setup-playbook.yml` needs the `setup-local` role, because it's copying `sites.json` to `/tmp/{{ inventory_hostname }}`

# Needed By (Date)
- Early next week?

# Criticality
- How critical is this PR on a 1-10 scale? 3/10
- It affects `acsf-site-setup-playbook.yml` and `full-migration-playbook.yml`

# Steps to Test

1. Check out `master`
2. Create an inventory with a site that does not exist `dev` or `test`
3. Run `acsf-site-setup-playbook.yml`
4. See the playbook fail at `add-vhost`
5. Repeat step 2.
6. Run `full-migration-playbook.yml`
7. See the playbook fail at `add-vhost`
8. Check out this branch
9. Repeat steps 2, 3, 5, and 6.
10. Succeed


# Affected Projects or Products
- Group/dept site migrations

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-695
- Other PRs: #60 
- Any other contextual information that might be helpful: the solution merged in #60 does not work in this case. We need to wait for the site to be fully provisioned on the Factory before attempting to add a custom domain or clearing the cache through the API. The solution to the problem illustrated in #60 is to only run `migration-sync-only-playbook.yml`. Or, we might need to come up with a different solution that ensures that the site is set up on the Factory, but bypasses fatal errors. We might want to replace the "Check drush can bootstrap site" task with a call to the API to get the site info.
- Anyone who should be notified? ( @minorwm )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)