### PR TITLE
SITES-986: Tweaks to site setup and migration sync playbooks

### DIFF
--- a/acsf-site-setup-playbook.yml
+++ b/acsf-site-setup-playbook.yml
@@ -39,4 +39,5 @@
     - { role: setup-local }
     - { role: setup-site }
     - { role: add-vhost }
-  serial: 12
+  serial: 6
+  max_fail_percentage: 100

--- a/migration-sync-only-playbook.yml
+++ b/migration-sync-only-playbook.yml
@@ -43,5 +43,5 @@
     - { role: acsf-optimizations }
     - { role: add-vhost }
     - { role: cleanup-local }
-  serial: 6
+  serial: 3
   max_fail_percentage: 100


### PR DESCRIPTION
No testing really should be needed here, it just dials down the number of tasks run in serial, and sets `max_fail_percentage=100`. These were the settings I used in creating and syncing the large-scale people and sites migrations.

"Trust me"