### PR TITLE
Sites 269

### DIFF
--- a/roles/acsf-optimizations/tasks/main.yml
+++ b/roles/acsf-optimizations/tasks/main.yml
@@ -38,5 +38,6 @@
 - name: Disable error reporting
   shell: "{{ drush_alias }} -y --exact vset error_level 0"
 
-- name: Enable stanford_dept
+- name: Enable stanford_dept again
   shell: "{{ drush_alias }} -y en stanford_dept"
+  ignore_errors: "yes"

--- a/roles/acsf-optimizations/tasks/main.yml
+++ b/roles/acsf-optimizations/tasks/main.yml
@@ -37,3 +37,6 @@
 
 - name: Disable error reporting
   shell: "{{ drush_alias }} -y --exact vset error_level 0"
+
+- name: Enable stanford_dept
+  shell: "{{ drush_alias }} -y en stanford_dept"

--- a/roles/acsf-optimizations/tasks/main.yml
+++ b/roles/acsf-optimizations/tasks/main.yml
@@ -38,6 +38,6 @@
 - name: Disable error reporting
   shell: "{{ drush_alias }} -y --exact vset error_level 0"
 
-- name: Enable stanford_dept again
+- name: Enable stanford_dept again to fix when drush rr disables it
   shell: "{{ drush_alias }} -y en stanford_dept"
   ignore_errors: "yes"

--- a/roles/acsf-optimizations/tasks/main.yml
+++ b/roles/acsf-optimizations/tasks/main.yml
@@ -38,6 +38,6 @@
 - name: Disable error reporting
   shell: "{{ drush_alias }} -y --exact vset error_level 0"
 
-- name: Enable stanford_dept again to fix when drush rr disables it
-  shell: "{{ drush_alias }} -y en stanford_dept"
-  ignore_errors: "yes"
+#- name: Enable stanford_dept again to fix when drush rr disables it
+#  shell: "{{ drush_alias }} -y en stanford_dept"
+#  ignore_errors: "yes"

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -64,6 +64,7 @@
     - "cc all"
     - "sqlq 'update system set status=\"1\" where name=\"stanford_dept\"'"
     - "-y en acsf"
+    - "-y en stanford_dept"
     - "rr"
   when: dept_site == "TRUE"
   notify: Clear site cache

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -65,7 +65,6 @@
     - "sqlq 'update system set status=\"1\" where name=\"stanford_dept\"'"
     - "-y en acsf"
     - "rr"
-    - "-y en stanford_dept"
   when: dept_site == "TRUE"
   notify: Clear site cache
 

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -62,11 +62,13 @@
   with_items:
     - "-y vset install_profile stanford_dept"
     - "cc all"
-    - "sqlq 'update system set status=\"1\" where name=\"stanford_dept\"'"
+#    - "sqlq 'update system set status=\"1\" where name=\"stanford_dept\"'"
+    - "-y en stanford_dept"
     - "-y en acsf"
     - "rr"
   when: dept_site == "TRUE"
   notify: Clear site cache
+  ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
 
 - name: Set SimpleSAMLphp Certs Dir
   set_fact:

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -64,8 +64,8 @@
     - "cc all"
     - "sqlq 'update system set status=\"1\" where name=\"stanford_dept\"'"
     - "-y en acsf"
-    - "-y en stanford_dept"
     - "rr"
+    - "-y en stanford_dept"
   when: dept_site == "TRUE"
   notify: Clear site cache
 

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -35,17 +35,6 @@
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
   notify: Clear site cache
 
-# BEANS, FEEDS, and probably bears too!
-# The change in where the entity class exists can cause fatal errors and not
-# allow the rest to continue. This drush rr is to ensure that all the PHP
-# classes are registered and in the right place before we try to run updates.
-- name: Run drush rr before running anything else if we're having issues
-  shell: "{{ drush_alias }} {{ item }}"
-  ignore_errors: yes
-  with_items:
-    - "-y rr"
-  ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
-
 # We sometimes have order-of-operation issues on drush updb. For instance, a
 # "Column not found: 1054 Unknown column 'base.status' in 'field list'" error.
 # To get past that, we can set ignore_updb_errors="TRUE" in our inventory on a
@@ -57,13 +46,25 @@
     - "-y updb"
   ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
 
-# This only runs "drush rr" if ignore_updb_errors == "TRUE"
-- name: Run drush rr before running drush updb a second time for recalcitrant sites
+
+# We must enable the profile as drush rr disables it.
+- name: Reenable the install profile after Rebuild the registry disables it.
   shell: "{{ drush_alias }} {{ item }}"
+  ignore_errors: yes
+  with_items:
+    - "-y en stanford_dept"
+
+
+# BEANS, FEEDS, and probably bears too!
+# The change in where the entity class exists can cause fatal errors and not
+# allow the rest to continue. This drush rr is to ensure that all the PHP
+# classes are registered and in the right place before we try to run updates.
+- name: Run drush rr before running anything else if we're having issues
+  shell: "{{ drush_alias }} {{ item }}"
+  ignore_errors: yes
   with_items:
     - "-y rr"
-  when: ignore_updb_errors == "TRUE"
-  ignore_errors: yes
+  ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
 
 # This only runs "drush updb" if ignore_updb_errors == "TRUE"
 - name: Run drush updb a second time for recalcitrant sites
@@ -78,3 +79,5 @@
   ignore_errors: yes
   with_items:
     - "-y rr"
+
+

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -35,6 +35,17 @@
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
   notify: Clear site cache
 
+# BEANS, FEEDS, and probably bears too!
+# The change in where the entity class exists can cause fatal errors and not
+# allow the rest to continue. This drush rr is to ensure that all the PHP
+# classes are registered and in the right place before we try to run updates.
+- name: Run drush rr before running anything else if we're having issues
+  shell: "{{ drush_alias }} {{ item }}"
+  ignore_errors: yes
+  with_items:
+    - "-y rr"
+  ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
+
 # We sometimes have order-of-operation issues on drush updb. For instance, a
 # "Column not found: 1054 Unknown column 'base.status' in 'field list'" error.
 # To get past that, we can set ignore_updb_errors="TRUE" in our inventory on a
@@ -46,23 +57,13 @@
     - "-y updb"
   ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
 
-# We must enable the profile as drush rr disables it.
-- name: Reenable the install profile after Rebuild the registry disables it.
+# This only runs "drush rr" if ignore_updb_errors == "TRUE"
+- name: Run drush rr before running drush updb a second time for recalcitrant sites
   shell: "{{ drush_alias }} {{ item }}"
-  ignore_errors: yes
-  with_items:
-    - "-y en stanford_dept"
-
-# BEANS, FEEDS, and probably bears too!
-# The change in where the entity class exists can cause fatal errors and not
-# allow the rest to continue. This drush rr is to ensure that all the PHP
-# classes are registered and in the right place before we try to run updates.
-- name: Run drush rr before running anything else if we're having issues
-  shell: "{{ drush_alias }} {{ item }}"
-  ignore_errors: yes
   with_items:
     - "-y rr"
-  ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
+  when: ignore_updb_errors == "TRUE"
+  ignore_errors: yes
 
 # This only runs "drush updb" if ignore_updb_errors == "TRUE"
 - name: Run drush updb a second time for recalcitrant sites
@@ -77,4 +78,3 @@
   ignore_errors: yes
   with_items:
     - "-y rr"
-    

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -35,13 +35,6 @@
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
   notify: Clear site cache
 
-# Let's enable the stanford_dept install profile
-- name: Enable stanford_dept before we rr
-  shell: "{{ drush_alias }} {{ item }}"
-  ignore_errors: yes
-  with_items:
-    - "-y en stanford_dept"
-
 # BEANS, FEEDS, and probably bears too!
 # The change in where the entity class exists can cause fatal errors and not
 # allow the rest to continue. This drush rr is to ensure that all the PHP

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -35,6 +35,13 @@
     - "sqlc < /tmp/{{ inventory_hostname }}/dbdump.sql"
   notify: Clear site cache
 
+# Let's enable the stanford_dept install profile
+- name: Enable stanford_dept before we rr
+  shell: "{{ drush_alias }} {{ item }}"
+  ignore_errors: yes
+  with_items:
+    - "-y en stanford_dept"
+
 # BEANS, FEEDS, and probably bears too!
 # The change in where the entity class exists can cause fatal errors and not
 # allow the rest to continue. This drush rr is to ensure that all the PHP

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -46,14 +46,12 @@
     - "-y updb"
   ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
 
-
 # We must enable the profile as drush rr disables it.
 - name: Reenable the install profile after Rebuild the registry disables it.
   shell: "{{ drush_alias }} {{ item }}"
   ignore_errors: yes
   with_items:
     - "-y en stanford_dept"
-
 
 # BEANS, FEEDS, and probably bears too!
 # The change in where the entity class exists can cause fatal errors and not
@@ -79,5 +77,4 @@
   ignore_errors: yes
   with_items:
     - "-y rr"
-
-
+    


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- drush registry-rebuild disables install profile of migrated sites.

# Needed By (Date)
- Yesterday

# Criticality
- How critical is this PR on a 1-10 scale? 5/10
- It affects `migration-sync-only-playbook.yml` and `full-migration-playbook.yml`

# Steps to Test
1. Run a site migration test using the spur-b dept. 

2. `drush @acsf.dev.cardinald7.suprib sqlq 'select name, status from system where name="stanford_dept"'` should return 1.

3. `drush @acsf.dev.cardinald7.suprib rr`

4. `drush @acsf.dev.cardinald7.suprib sqlq 'select name, status from system where name="stanford_dept"'` should STILL return 1.

# Affected Projects or Products
- Group/dept site migrations

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-269
- Other PRs: N/A
- Any other contextual information that might be helpful: Here was the lead I went off of ( https://www.drupal.org/project/drupal/issues/1170362#comment-12823812 ). I found that adding the step to enable the stanford_dept install profile fixes this issue. I tried adding this to the "Set site up as a Department site" task in the post-db-restore role, but it didn't work. I moved it further down and it did. There's probably something in-between the post-db-restore role and the acsf-optimizations role that's causing this.
- Anyone who should be notified? ( @jbickar  )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)