### PR TITLE
SITES-950: chmod to overcome AFS ACLs

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -44,3 +44,7 @@ enable_maintenance_mode_source: "FALSE"
 # Set disable_maintenance_mode_dest to TRUE initially, to avoid undefined
 # variable errors. It can be overridden in migration_vars.yml
 disable_maintenance_mode_dest: "FALSE"
+
+# This is a little-used variable; only used when there are file permissions
+# issues from files that were not created/saved by Drupal.
+chmod: "FALSE"

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -99,6 +99,16 @@
   when: launch_tasks == ""
   notify: Clear site cache
 
+# Chmod files directory so that there are not permission issues when going from
+# AFS ACLs to Unix file permissions
+- name: Make all files readable on AFS
+  file:
+    path: "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/"
+    recurse: yes
+    mode: "a+r,o-w"
+  when:
+    afs_available == "TRUE"
+
 # Copy public files so that they exist and Drupal can find them if needed
 - name: Copy public files from local to Site Factory
   shell: "drush -y rsync /tmp/{{ inventory_hostname }}/files/ @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}:%files/ --exclude-paths=sites/default/files/js_injector/"

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -107,7 +107,7 @@
     recurse: yes
     mode: "a+r"
   when:
-    afs_available == "TRUE"
+    afs_available == "TRUE" and chmod == "TRUE"
 
 # Copy public files so that they exist and Drupal can find them if needed
 - name: Copy public files from local to Site Factory

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -105,7 +105,7 @@
   file:
     path: "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/"
     recurse: yes
-    mode: "a+r,o-w"
+    mode: "a+r"
   when:
     afs_available == "TRUE"
 

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -99,7 +99,7 @@
   when: launch_tasks == ""
   notify: Clear site cache
 
-# Chmod files directory so that there are not permission issues when going from
+# chmod files directory so that there are not permissions issues when going from
 # AFS ACLs to Unix file permissions
 - name: Make all files readable on AFS
   file:

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -105,7 +105,7 @@
   file:
     path: "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/"
     recurse: yes
-    mode: "a+r"
+    mode: "u=rwX,g=rX,o=rX"
   when:
     afs_available == "TRUE" and chmod == "TRUE"
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix file perms

# Needed By (Date)
- Before we migrate the next site with file permissions issues

# Criticality
- How critical is this PR on a 1-10 scale? 3/10

# Steps to Test

0. Check out `master`
1. `chmod 600 /afs/ir/dist/drupal/ds_sws-migration-testing/files/california-128.png`
2. Sync `sws-migration-testing` to dev
3. Go to https://sws-migration-testing-dev.sites.stanford.edu/file-permissions-test-sites-950
4. See no image
5. Check out this branch
6. Add `chmod: "TRUE"` to your `migration_vars.yml`
7. `chmod 600 /afs/ir/dist/drupal/ds_sws-migration-testing/files/california-128.png`
8. Sync `sws-migration-testing` to dev
9. Go to https://sws-migration-testing-dev.sites.stanford.edu/file-permissions-test-sites-950
10. See image of California flag

# Additional Contextual Information
1. This requires **both** `afs_available="TRUE"` _and_ a new variable, `chmod="TRUE"`
2. I did not see the sense in multi-purposing this for when AFS is not available; we only will need it in a very small set of circumstances.
3. This makes permanent (but reversible) changes to file permissions on the source site. It does not track the previous file permissions. This is a calculated risk between expediency and safety.
4. This is not an option that we want to use unless we have to. (It's not really that risky, but I don't want to get in the habit of making permanent file permission changes.)

# Affected Projects or Products
- Sites with images/files that have been manually synced

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-950
- Anyone else who should be notified? @pookmish and @kbrownell 


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

