### PR TITLE
SITES-1118: Enable installation profile after detecting it

### DIFF
--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -47,7 +47,7 @@
 # to be sure to set "install_profile" to "stanford_sites_jumpstart_academic" for
 # JSA sites (so that they get all the correct code).
 - name: Find and set the install profile by helper modules.
-  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; fi;"
+  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; {{ drush_alias }} -y sqlq 'update system set status=\"1\" where name=\"{{ item.profile }}\"'; fi;"
   with_items:
     - { module: 'stanford_jumpstart', profile: 'stanford_sites_jumpstart' }
     - { module: 'stanford_jumpstart_plus', profile: 'stanford_sites_jumpstart_plus' }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Enable the install profile during migration

# Needed By (Date)
- Next week sometime

# Criticality
- How critical is this PR on a 1-10 scale? 4/10
- It seems to be hitting a lot of sites

# Steps to Test

1. Migrate `sa-haas2` to `dev` or `test` using the `master` branch
2. Run `drush sqlq --extra="-t" 'select name,status,schema_version from system where name="stanford_sites_jumpstart_vpsa"'`
3. See that `status==0`
4. Check out this branch
5. Repeat Steps 1 and 2
6. See that `status==1`


# Affected Projects or Products
- All of our JS* sites

# Associated Issues and/or People
- JIRA tickets:
    - https://stanfordits.atlassian.net/browse/SITES-1118
    - https://stanfordits.atlassian.net/browse/SITES-269
- Other PRs: #79 
- Anyone who should be notified? ( @minorwm )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)