### PR TITLE
SITES-734: Protect prod using DNS lookup

### DIFF
--- a/roles/protect-prod/meta/main.yml
+++ b/roles/protect-prod/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - { role: get-sitename }
+  - { role: define-paths }

--- a/roles/protect-prod/tasks/main.yml
+++ b/roles/protect-prod/tasks/main.yml
@@ -7,9 +7,10 @@
 # in which acsf_site_name and existing_sites have values.
 #
 # INPUTS:
-#   inventory_hostname
+#   absolute_vhost_path_sites_service
 #   acsf_site_name
 #   acsf_environment
+#   inventory_hostname
 #   prod_sites
 #
 # OUTPUTS:
@@ -37,5 +38,20 @@
   when: acsf_site_name in prod_sites and acsf_environment == ""
 
 - name: Look up DNS for vhost
-  set_fact:
-    dns_lookup: {{ lookup('dig', absolute_vhost_path_sites_service )}}
+  shell: "dig +short {{ absolute_vhost_path_sites_service }}"
+  register: dig_output
+
+- name: Debug dns_lookup variable
+  debug:
+    msg: "DNS lookup is: {{ dig_output.stdout_lines }}"
+  when:
+    print_debug_messages == "TRUE"
+
+# If DNS for <hostname>.stanford.edu already is pointed to ACSF (i.e., the
+# results of "dig" return "*.cardinalsites.acsitefactory.com"), then fail.
+# This protects production sites from being wiped out.
+# See https://stanfordits.atlassian.net/browse/SITES-734.
+- name: Fail if DNS for hostname is already on ACSF
+  fail:
+    msg: "{{ absolute_vhost_path_sites_service }} is already pointed to ACSF. You cannot migrate over a production site."
+  when: dig_output.stdout is search("cardinalsites.acsitefactory.com") and acsf_environment == ""

--- a/roles/protect-prod/tasks/main.yml
+++ b/roles/protect-prod/tasks/main.yml
@@ -35,3 +35,7 @@
     msg: "{{ acsf_site_name }} conflicts with an inventory hostname on our list of protected production sites."
   # Only fail for production environment
   when: acsf_site_name in prod_sites and acsf_environment == ""
+
+- name: Look up DNS for vhost
+  set_fact:
+    dns_lookup: {{ lookup('dig', absolute_vhost_path_sites_service )}}


### PR DESCRIPTION
# READY FOR REVIEW
- (Will be ready by 4:35PM PST on 01/07)

# Summary
- Saves us from having to manually update https://github.com/SU-SWS/ansible-sync/blob/master/prod-sites.yml every time we cut a site over to ACSF
- Prevents blowing away prod sites if their DNS is pointed to ACSF

# Needed By (Date)
- The sooner the better

# Criticality
- How critical is this PR on a 1-10 scale? 5/10
- It would have been nice to have this a while ago but better late than never

# Steps to Test

1. Check out this branch on one of the `people` servers
2. Create this inventory:
```
[groups]
sites734 vhost="sites734"

[groups:vars]
group_ids=206
```
3. Migrate that inventory to **prod** (`acsf_environment: ""`)
4. See that the migration fails with the error message "sites734.stanford.edu  is already pointed to ACSF. You cannot migrate over a production site."

# Affected Projects or Products
- ACSF migrations

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-734
- Other PRs: https://github.com/SU-SWS/ansible-sync/pull/9
- Anyone who should be notified? ( @sherakama )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)