### PR TITLE
SITES-1122: Disable stanford and stanford_dept profiles for product sites

### DIFF
--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -47,7 +47,7 @@
 # to be sure to set "install_profile" to "stanford_sites_jumpstart_academic" for
 # JSA sites (so that they get all the correct code).
 - name: Find and set the install profile by helper modules.
-  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; {{ drush_alias }} -y sqlq 'update system set status=\"1\" where name=\"{{ item.profile }}\"'; {{ drush_alias }} -y sqlq 'update system set status=\"0\" where name in (\"stanford\",\"stanford_dept\")'; {{ drush_alias }} -y en stanford_jumpstart_shortcuts; fi;"
+  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; {{ drush_alias }} -y sqlq 'update system set status=\"1\" where name=\"{{ item.profile }}\"'; {{ drush_alias }} -y sqlq 'update system set status=\"0\" where name in (\"stanford\",\"stanford_dept\")'; {{ drush_alias }} -y en stanford_jumpstart_shortcuts stanford_jumpstart_site_actions; fi;"
   with_items:
     - { module: 'stanford_jumpstart', profile: 'stanford_sites_jumpstart' }
     - { module: 'stanford_jumpstart_plus', profile: 'stanford_sites_jumpstart_plus' }

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -47,7 +47,7 @@
 # to be sure to set "install_profile" to "stanford_sites_jumpstart_academic" for
 # JSA sites (so that they get all the correct code).
 - name: Find and set the install profile by helper modules.
-  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; {{ drush_alias }} -y sqlq 'update system set status=\"1\" where name=\"{{ item.profile }}\"'; fi;"
+  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; {{ drush_alias }} -y sqlq 'update system set status=\"1\" where name=\"{{ item.profile }}\"'; {{ drush_alias }} -y sqlq 'update system set status=\"0\" where name in (\"stanford\",\"stanford_dept\")'; fi;"
   with_items:
     - { module: 'stanford_jumpstart', profile: 'stanford_sites_jumpstart' }
     - { module: 'stanford_jumpstart_plus', profile: 'stanford_sites_jumpstart_plus' }

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -47,7 +47,7 @@
 # to be sure to set "install_profile" to "stanford_sites_jumpstart_academic" for
 # JSA sites (so that they get all the correct code).
 - name: Find and set the install profile by helper modules.
-  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; {{ drush_alias }} -y sqlq 'update system set status=\"1\" where name=\"{{ item.profile }}\"'; {{ drush_alias }} -y sqlq 'update system set status=\"0\" where name in (\"stanford\",\"stanford_dept\")'; fi;"
+  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; {{ drush_alias }} -y sqlq 'update system set status=\"1\" where name=\"{{ item.profile }}\"'; {{ drush_alias }} -y sqlq 'update system set status=\"0\" where name in (\"stanford\",\"stanford_dept\")'; {{ drush_alias }} -y en stanford_jumpstart_shortcuts; fi;"
   with_items:
     - { module: 'stanford_jumpstart', profile: 'stanford_sites_jumpstart' }
     - { module: 'stanford_jumpstart_plus', profile: 'stanford_sites_jumpstart_plus' }

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -47,7 +47,7 @@
 # to be sure to set "install_profile" to "stanford_sites_jumpstart_academic" for
 # JSA sites (so that they get all the correct code).
 - name: Find and set the install profile by helper modules.
-  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; {{ drush_alias }} -y sqlq 'update system set status=\"1\" where name=\"{{ item.profile }}\"'; {{ drush_alias }} -y sqlq 'update system set status=\"0\" where name in (\"stanford\",\"stanford_dept\")'; {{ drush_alias }} -y en stanford_jumpstart_shortcuts stanford_jumpstart_site_actions; fi;"
+  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; {{ drush_alias }} -y sqlq 'update system set status=\"1\" where name=\"{{ item.profile }}\"'; {{ drush_alias }} -y sqlq 'update system set status=\"0\" where name=\"stanford\"'; {{ drush_alias }} -y en stanford_jumpstart_shortcuts stanford_jumpstart_site_actions; fi;"
   with_items:
     - { module: 'stanford_jumpstart', profile: 'stanford_sites_jumpstart' }
     - { module: 'stanford_jumpstart_plus', profile: 'stanford_sites_jumpstart_plus' }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Enables access to the Site Actions menu for older JS* sites

# Needed By (Date)
- Soon would be good.

# Criticality
- How critical is this PR on a 1-10 scale? 3/10
- Only affects older JS* sites, AFAIK

# Steps to Test

1. Check out this branch
2. Migrate `jumpstart-argc`, `jumpstart-svndl`, `jumpstart-hsdofinance` and/or `jumpstart-sparq` to dev or test
3. Log in and ensure that you see the Site Actions menu

# Affected Projects or Products
- Older JS* sites

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-1122
- Any other contextual information that might be helpful: on certain sites (e.g., music-dept, public-policy, philosophy), it was necessary to disable `stanford_jumpstart_shortcuts` (which also disables its dependencies), _uninstall_ `stanford_jumpstart_site_actions`, and then _re-enable_ the modules that were disabled (including `stanford_jumpstart_site_actions`). I could not think of a reliable way to scale that without adding some tortured logic and exploding scope, so we will just do that for those sites as an after-migration manual step.
- Anyone who should be notified? ( @minorwm )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)