### PR TITLE
SITES-838: Adding a task to rebuild content permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ ansible-sync
 migration_vars.yml
 server_vars.yml
 roles/setup-local/templates/acsf.aliases.drushrc.php
+*.sql
 

--- a/default.migration_vars.yml
+++ b/default.migration_vars.yml
@@ -56,6 +56,11 @@ sites_drush_prefix: "default"
 # --extra-vars "print_debug_messages=TRUE"
 print_debug_messages: "FALSE"
 
+# Rebuild content permissions. Set to FALSE by default; you can set it to
+# TRUE in migration_vars.yml, or set it at runtime with
+# --extra-vars "rebuild_permissions=TRUE"
+rebuild_permissions: "FALSE"
+
 #
 # Enable direct AFS access when running ansible on an AFS ready environment.
 # Example: TRUE

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -31,7 +31,7 @@ drush_environment: ""
 # This variable (ignore_updb_errors) should be set to an empty string by
 # default, in order to avoid "undefined variable" error messages. It can be
 # set on a per-site basis to "TRUE" in the inventory file. It is case-sensitive.
-ignore_updb_errors: ""
+ignore_updb_errors: "TRUE"
 
 # Set site_exists to FALSE initially to avoid undefined variable errors. See
 # roles/setup-site/tasks/main.yml.

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -88,10 +88,15 @@
     - "sqlq 'truncate table webauth_roles_history'"
     - "sspwmd"
     - "-y pm-uninstall webauth_extras"
-    # Rebuild content permissions.
-    - 'php-eval "node_access_rebuild();"'
   notify: Clear site cache
   ignore_errors: "yes"
+
+- name: Rebuild content permissions
+  shell: "{{ drush_alias }} {{ item }}"
+  with_items:
+    - 'php-eval "node_access_rebuild();"'
+  when: rebuild_permissions == "TRUE"
+  notify: Clear site cache
 
 - name: Post-database-restore tasks if not launch
   shell: "{{ drush_alias }} {{ item }}"

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -91,6 +91,9 @@
   notify: Clear site cache
   ignore_errors: "yes"
 
+# Rebuild permissions. This resolves the "The content access permissions need
+# to be rebuilt" message. NOTE: this is a slow task, so only run this as
+# needed on a per-host basis
 - name: Rebuild content permissions
   shell: "{{ drush_alias }} {{ item }}"
   with_items:

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -88,6 +88,8 @@
     - "sqlq 'truncate table webauth_roles_history'"
     - "sspwmd"
     - "-y pm-uninstall webauth_extras"
+    # Rebuild content permissions.
+    - 'php-eval "node_access_rebuild();"'
   notify: Clear site cache
   ignore_errors: "yes"
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Create an option to rebuild content permissions.

# Needed By (Date)
- Yesterday

# Criticality
- How critical is this PR on a 1-10 scale? 5/10
- It affects `migration-sync-only-playbook.yml`, `full-migration-playbook.yml`, and `post-db-restore-playbook.yml`

# Steps to Test
1. Run a site migration test using the music-dept. Use the `--extra-vars "rebuild_permissions=TRUE"` in your ansible-playbook command. Here's an example: `ansible-playbook -i inventory/minorwm-test full-migration-playbook.yml --extra-vars "rebuild_permissions=TRUE"` 

# Affected Projects or Products
- Group/dept site migrations

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-838
- Anyone who should be notified? ( @jbickar  )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)