### PR TITLE
SITES-952: Adding the call to the admin-shortcuts.php script

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -55,3 +55,11 @@ chmod: "FALSE"
 # See roles/change-paths/tasks/main.yml, the "Remove absolute paths for links
 # and menus" and "Remove absolute vhost paths for links and menus" tasks.
 run_sarl: "TRUE"
+
+# stanford_jumpstart_shortcuts defines permissions to allow access to "top
+# reports" menu items ("Recent log messages", "Top 'access denied' errors",
+# "Top 'page not found' errors", and "Top search phrases"). It also places
+# these items in the Site Actions menu. To disable (not delete) these items
+# from the Site Actions menu, set disable_top_reports_menu_items: "TRUE"
+# in migration_vars.yml or in an inventory file.
+disable_top_reports_menu_items: "FALSE"

--- a/roles/change-paths/tasks/main.yml
+++ b/roles/change-paths/tasks/main.yml
@@ -207,3 +207,8 @@
 - name: Save modified JS Injector rules to disk
   shell: "{{ drush_alias }} scr {{ scripts_dir }}/js-injector.php"
   notify: Clear site cache
+
+# Ex. drush @acsf.test.cardinald7.eao scr /var/www/html/cardinald7.02test/scripts/admin-shortcuts.php
+- name: Hide reports menu links from admin shortcuts
+  shell: "{{ drush_alias }} scr {{ scripts_dir }}/admin-shortcuts.php"
+  notify: Clear site cache

--- a/roles/change-paths/tasks/main.yml
+++ b/roles/change-paths/tasks/main.yml
@@ -212,3 +212,4 @@
 - name: Hide reports menu links from admin shortcuts
   shell: "{{ drush_alias }} scr {{ scripts_dir }}/admin-shortcuts.php"
   notify: Clear site cache
+  when: disable_top_reports_menu_items == "TRUE"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This runs the script for removing reports menu items from the admin shortcuts menu .

# Needed By (Date)
- 01/15/2019

# Urgency
- 7/10

# Steps to Test

1. Run the full migration using this branch on the dev or test server you used.
2. Go to the `admin/stanford/jumpstart/shortcuts/site-actions` page and make sure the links do not show.

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SITES-952
- Script PR: https://github.com/SU-SWS/acsf-cardinald7/pull/164

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)