### PR TITLE
SITES-900: skip stanford_person_views_update_7500()

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -63,3 +63,9 @@ run_sarl: "TRUE"
 # from the Site Actions menu, set disable_top_reports_menu_items: "TRUE"
 # in migration_vars.yml or in an inventory file.
 disable_top_reports_menu_items: "FALSE"
+
+# Some sites fail on the stanford_person_views_update_7500() update hook.
+# We want to selectively skip over that hook on a per-site basis.
+# Set this variable to "TRUE" in an inventory or in migration_vars.yml to
+# skip past that update hook.
+skip_stanford_person_views_update_7500: "FALSE"

--- a/roles/upload-site/tasks/main.yml
+++ b/roles/upload-site/tasks/main.yml
@@ -57,6 +57,14 @@
     - "-y updb"
   ignore_errors: "{% if ignore_updb_errors == 'TRUE' %}yes{% endif %}"
 
+# Sometimes we want to skip ahead of the stanford_person_views_update_7500()
+# update hook.
+- name: Skip stanford_person_views_update_7500 update hook
+  shell: "{{ drush_alias }} {{ item }}"
+  with_items:
+    - "sqlq 'update system set schema_version=\"7500\" where name=\"stanford_person_views\"'"
+  when: ignore_updb_errors == "TRUE" and skip_stanford_person_views_update_7500 == "TRUE"
+
 # This only runs "drush rr" if ignore_updb_errors == "TRUE"
 - name: Run drush rr before running drush updb a second time for recalcitrant sites
   shell: "{{ drush_alias }} {{ item }}"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Some sites fail on the stanford_person_views_update_7500() update hook. We want to selectively skip over that hook on a per-site basis.

# Needed By (Date)
- Whenever we do final cutover of the next round of H&S sites

# Criticality
- How critical is this PR on a 1-10 scale? 3/10
- It's the only thing blocking a number of sites from moving to ACSF

# Steps to Test

1. Check out this branch
2. Migrate linguistics with this inventory:
```
[products]
linguistics vhost="linguistics" skip_stanford_person_views_update_7500="TRUE"

[products:vars]
group_ids=671
```
3. See that it migrates successfully

# Affected Projects or Products
- H&S ACSF migrations

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-900

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)