### PR TITLE
SITES-1173: "cannot redeclare" fatal error on JSVPSA sites

### DIFF
--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -47,7 +47,7 @@
 # to be sure to set "install_profile" to "stanford_sites_jumpstart_academic" for
 # JSA sites (so that they get all the correct code).
 - name: Find and set the install profile by helper modules.
-  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; {{ drush_alias }} -y sqlq 'update system set status=\"1\" where name=\"{{ item.profile }}\"'; {{ drush_alias }} -y sqlq 'update system set status=\"0\" where name=\"stanford\"'; {{ drush_alias }} -y en stanford_jumpstart_shortcuts stanford_jumpstart_site_actions; fi;"
+  shell: "FOUND=$({{ drush_alias }} php-eval \"var_dump(module_exists('{{ item.module }}'));\"); if [[ \"$FOUND\" =~ 'true' ]]; then {{ drush_alias }} -y vset install_profile '{{ item.profile }}'; {{ drush_alias }} -y sqlq 'update system set status=\"1\" where name=\"{{ item.profile }}\"'; {{ drush_alias }} -y sqlq 'update system set status=\"0\" where name=\"stanford\"'; {{ drush_alias }} rr; {{ drush_alias }} -y en stanford_jumpstart_shortcuts stanford_jumpstart_site_actions; fi;"
   with_items:
     - { module: 'stanford_jumpstart', profile: 'stanford_sites_jumpstart' }
     - { module: 'stanford_jumpstart_plus', profile: 'stanford_sites_jumpstart_plus' }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- JSVPSA sites get a fatal error "cannot redeclare" one of the stanford_bean_types functions, because there's a duplicate in `profiles/stanford_sites_jumpstart_vpsa/modules`. This resolves that error.

# Needed By (Date)
- Whenever we are able to migrate the VPSA sites. Next week sometime.

# Criticality
- How critical is this PR on a 1-10 scale? 7/10
- Currently blocked from migrating any JSVPSA sites

# Steps to Test

1. Check out this branch
2. Migrate a few VPSA and JS* sites to dev or test, say:
```
sa-a3c vhost="a3c"
sa-bcsc vhost="bcsc"
sa-bechtel vhost="bechtel"
jumpstart-argc
jumpstart-svndl
jumpstart-hsdofinance
jumpstart-sparq
```
3. Ensure that the JSVPSA sites migrate cleanly
4. Ensure that you can see the Site Actions menu on the JS* sites

# Affected Projects or Products
- ACSF, JS/JS+/JSVPSA

# Associated Issues and/or People
- JIRA ticket: SITES-1173
- Other PRs: #89 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

