### PR TITLE
SITES-950: File permissions

### DIFF
--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -120,6 +120,15 @@
   when:
     afs_available == "TRUE" and chmod == "TRUE"
 
+# chmod the files directory on AFS back to 777.
+- name: Make files directory writable on AFS
+  file:
+    path: "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/"
+    recurse: no
+    mode: "777"
+  when:
+    afs_available == "TRUE" and chmod == "TRUE"
+
 # Copy public files so that they exist and Drupal can find them if needed
 - name: Copy public files from local to Site Factory
   shell: "drush -y rsync /tmp/{{ inventory_hostname }}/files/ @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}:%files/ --exclude-paths=sites/default/files/js_injector/"

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -120,15 +120,6 @@
   when:
     afs_available == "TRUE" and chmod == "TRUE"
 
-# chmod the files directory on AFS back to 777.
-- name: Make files directory writable on AFS
-  file:
-    path: "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/"
-    recurse: no
-    mode: "777"
-  when:
-    afs_available == "TRUE" and chmod == "TRUE"
-
 # Copy public files so that they exist and Drupal can find them if needed
 - name: Copy public files from local to Site Factory
   shell: "drush -y rsync /tmp/{{ inventory_hostname }}/files/ @acsf{{ drush_environment }}.{{ stack }}.{{ acsf_site_name }}:%files/ --exclude-paths=sites/default/files/js_injector/"
@@ -156,6 +147,15 @@
   notify: Clear site cache
   when:
     afs_available == "TRUE"
+
+# chmod the files directory on AFS back to 777.
+- name: Make files directory writable on AFS
+  file:
+    path: "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/"
+    recurse: no
+    mode: "777"
+  when:
+    afs_available == "TRUE" and chmod == "TRUE"
 
 - name: Generate random password
 # See https://stackoverflow.com/a/45080709


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Change the `files` directory back to 777 on AFS

# Needed By (Date)
- We'll need this for SOE department site migrations

# Criticality
- How critical is this PR on a 1-10 scale? 3/10

# Steps to Test

1. `chmod 755 /afs/ir/dist/drupal/ds_sws-migration-testing/files`
2. Try to upload a file on https://sws-oddball-vhost.stanford.edu/
3. Fail
4. Migrate `sws-migration-testing vhost="sws-oddball-vhost"` to `dev` or `test`
5. Try to upload a file on https://sws-oddball-vhost.stanford.edu/ and succeed
6. Ensure that `sites/g/files/sbiybj5005321dev/f` is 755

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-950
- Other PRs: #78 
- Any other contextual information that might be helpful: see comments in JIRA ticket
- Anyone who should be notified? ( @cjwest )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)