### PR TITLE
SITES-1190: add task to set acsf_helper_canonical_url at launch

### DIFF
--- a/roles/add-vhost/tasks/main.yml
+++ b/roles/add-vhost/tasks/main.yml
@@ -58,3 +58,9 @@
     return_content: yes
     register: inventory_hostname_domain_response
   when: inventory_hostname != acsf_site_name and sites_service == "sites"
+
+# Force loading through the canonical URL by setting the "acsf_helper_canonical_url"
+# variable to (e.g.) "foo.stanford.edu"
+- name: Set acsf_helper_canonical_url variable prior to launch
+  shell: "{{ drush_alias }} -y --exact vset acsf_helper_canonical_url  {{ new_absolute_path }}"
+  when: launch_tasks == "launch"

--- a/roles/add-vhost/tasks/main.yml
+++ b/roles/add-vhost/tasks/main.yml
@@ -62,5 +62,5 @@
 # Force loading through the canonical URL by setting the "acsf_helper_canonical_url"
 # variable to (e.g.) "foo.stanford.edu"
 - name: Set acsf_helper_canonical_url variable prior to launch
-  shell: "{{ drush_alias }} -y --exact vset acsf_helper_canonical_url  {{ new_absolute_path }}"
+  shell: "{{ drush_alias }} -y --exact vset acsf_helper_canonical_url {{ new_absolute_path }}"
   when: launch_tasks == "launch"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When `launch_tasks="launch"`, sets the Drupal variable of `acsf_helper_canonical_url` to the hostname of the site, only on prod.

# Needed By (Date)
- Tuesday, February 5th

# Criticality
- How critical is this PR on a 1-10 scale? 6/10
- We are migrating 90+ sites on Tuesday evening, and I would like to set this for all of them as part of the migration process

# Steps to Test

1. Check out this branch
2. Migrate the following inventory to `prod`:
```
[groups]
sws-migration-testing vhost="sws-oddball-vhost"

[groups:vars]
group_ids=206
```
3. Go to https://swsmigrationtesting.sites.stanford.edu
4. Get redirected to https://sws-oddball-vhost.stanford.edu/ (that host is still in Sites 1.x; thus you see the potential risks in this approach)

# Affected Projects or Products
- [JS/JS+ cutovers](https://stanfordits.atlassian.net/browse/SITES-1147)

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-1190
- Any other contextual information that might be helpful: this has some risks, in that it forces a site to load through a given URL. This means that it is not possible to preview a site before the DNS switch has happened. We mitigate this by only doing it as a condition of `launch_tasks="launch"`. We'll see in practice whether this is enough of a mitigation; for instance, this would not work for the H&S migrations, where they need to go in and change some things on the sites in between final sync and DNS cutover. However, setting this variable is reversible.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)