### PR TITLE
SITES-950: chmod subdirectories to 777

### DIFF
--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -151,14 +151,9 @@
 # chmod the files directory on AFS back to 777.
 - name: Make files directory writable on AFS
   file:
-    path: "{{ item }}"
-    recurse: no
+    path: "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/"
+    recurse: yes
     mode: "777"
-  with_items:
-    - "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/"
-    - "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/private/"
-    - "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/css/"
-    - "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/js/"
   when:
     afs_available == "TRUE" and chmod == "TRUE"
 

--- a/roles/post-db-restore/tasks/main.yml
+++ b/roles/post-db-restore/tasks/main.yml
@@ -151,9 +151,14 @@
 # chmod the files directory on AFS back to 777.
 - name: Make files directory writable on AFS
   file:
-    path: "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/"
+    path: "{{ item }}"
     recurse: no
     mode: "777"
+  with_items:
+    - "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/"
+    - "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/private/"
+    - "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/css/"
+    - "/afs/ir/dist/drupal/{{ site_prefix }}_{{ inventory_hostname }}/files/js/"
   when:
     afs_available == "TRUE" and chmod == "TRUE"
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Recursively `chmod 777` on `sites/default/files`

# Needed By (Date)
- 2.7.2019

# Criticality
- How critical is this PR on a 1-10 scale? 3/10
- We hit permissions errors on the private files directory today on insidesoe

# Steps to Test

1. `chmod -R /afs/ir/dist/drupal/ds_sws-migration-testing/files/`
2. Check out this branch
3. Migrate `ds_sws-migration-testing`
4. Verify that `/afs/ir/dist/drupal/ds_sws-migration-testing/files/` has 777 perms

# Affected Projects or Products
- Legacy sites on sites1/sites2

# Associated Issues and/or People
- JIRA ticket: SITES-950
- Other PRs: #78 , #91  
- Any other contextual information that might be helpful: it's OK to do this because AFS ACLs, not Unix permissions, control access
- Anyone who should be notified? ( @cjwest )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)