### PR TITLE
SITES-000: fix bug with checking for vhost.stanford.edu

### DIFF
--- a/playbooks/add-vhost-playbook.yml
+++ b/playbooks/add-vhost-playbook.yml
@@ -31,6 +31,6 @@
 
   vars_files:
     - ../migration_vars.yml
-
+    - ../ansible-sync/prod-sites.yml
   roles:
     - { role: roles/add-vhost }

--- a/roles/add-vhost/tasks/main.yml
+++ b/roles/add-vhost/tasks/main.yml
@@ -58,7 +58,7 @@
   when: vhost_sitespro_custom_domain_exists_check.stdout is search('Resource not found')
 
 - name: Check if vhost.stanford.edu exists as a custom domain
-  shell: "{{ drush_alias }} ac-domain-info {{ vhost }}{{ stanford_environment }}.sites-pro.stanford.edu"
+  shell: "{{ drush_alias }} ac-domain-info {{ vhost }}.stanford.edu"
   register: vhost_custom_domain_exists_check
   ignore_errors: "yes"
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixes a bug in checking to see if `vhost.stanford.edu` is on StanfordPro

# Needed By (Date)
- Wednesday, February 27th

# Criticality
- How critical is this PR on a 1-10 scale? 2/10 
- we can add it manually

# Steps to Test

0. Check out this branch
1. Migrate `mlk vhost="kinginstitute" launch_tasks="launch"` to `prod` with the `playbooks/add-vhost-playbook.yml` playbook
2. Check that `kinginstitute.stanford.edu` has been added as a custom domain in [the Cloud interface](https://cloud.acquia.com/app/develop/applications/537638ba-b0c3-4bbb-92c5-be0e2a34a6a1/environments/34354-537638ba-b0c3-4bbb-92c5-be0e2a34a6a1/domains)
3. Run `drush @stanfordpro.prod.mlk vdel stanfordpro_helper_canonical_url -y` to delete the stanfordpro_helper_canonical_url variable

# Affected Projects or Products
- StanfordPro migrations

# Associated Issues and/or People
- N/A

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)